### PR TITLE
Made possible to include objectManager.ipp in applications.

### DIFF
--- a/libs/client/util/files.cmake
+++ b/libs/client/util/files.cmake
@@ -15,10 +15,10 @@ set(EQ_UTIL_FORWARD_HEADERS
   util/objectManager.ipp
   util/texture.h
   util/types.h
+  util/gpuCompressor.h
   )
 
 set(EQ_UTIL_HEADERS
-  util/gpuCompressor.h
   )
 
 set(EQ_UTIL_SOURCES

--- a/libs/client/util/gpuCompressor.h
+++ b/libs/client/util/gpuCompressor.h
@@ -19,7 +19,7 @@
 #ifndef EQUTIL_GPUCOMPRESSOR_H
 #define EQUTIL_GPUCOMPRESSOR_H
 
-#include "../../collage/base/compressor.h" // base class
+#include <co/base/compressor.h> // base class
 #include <eq/fabric/types.h>
 #include <eq/api.h>
 

--- a/libs/client/util/objectManager.ipp
+++ b/libs/client/util/objectManager.ipp
@@ -16,13 +16,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "objectManager.h"
+#include <eq/util/objectManager.h>
 
-#include "accum.h"
-#include "bitmapFont.h"
-#include "frameBufferObject.h"
-#include "gpuCompressor.h"
-#include "texture.h"
+#include <eq/util/accum.h>
+#include <eq/util/bitmapFont.h>
+#include <eq/util/frameBufferObject.h>
+#include <eq/util/gpuCompressor.h>
+#include <eq/util/texture.h>
 
 #include <string.h>
 

--- a/libs/collage/base/files.cmake
+++ b/libs/collage/base/files.cmake
@@ -53,10 +53,10 @@ set(COBASE_FORWARD_HEADERS
     types.h
     uint128_t.h
     uuid.h
+    compressor.h
   )
 
 set(COBASE_HEADERS 
-    compressor.h
     compressorInfo.h
     cpuCompressor.h
     memcpy.h


### PR DESCRIPTION
In order to make custom type object managers it is required to include objectManager.ipp, this was not possible before due to compilation errors. Check my update, it solves the issue.
