### PR TITLE
propagate non-standard GLEW location to examples & tests

### DIFF
--- a/examples/CMakeLists.in.txt
+++ b/examples/CMakeLists.in.txt
@@ -58,6 +58,14 @@ endfunction(EQ_ADD_EXAMPLE NAME)
 
 include_directories(include)
 
+if(GLEW_MX_FOUND)
+  include_directories(BEFORE SYSTEM ${GLEW_MX_INCLUDE_DIRS})
+  set(GLEW_LIBRARY ${GLEW_MX_LIBRARIES})
+else()
+  set(GLEW_LIBRARY "GLEW_MX-Equalizer")
+  add_definitions(-DGLEW_STATIC=1 -DGLEW_MX=1)
+endif()
+
 install(DIRECTORY configs DESTINATION share/Equalizer
         COMPONENT data PATTERN ".svn" EXCLUDE)
 

--- a/libs/GLEW/CMakeLists.txt
+++ b/libs/GLEW/CMakeLists.txt
@@ -2,7 +2,7 @@
 #               2011 Stefan Eilemann <eile@eyescale.ch>
 
 if(GLEW_MX_FOUND)
-  include_directories(BEFORE SYSTEM ${GLEW_MX_INCLUDE_DIR})
+  include_directories(BEFORE SYSTEM ${GLEW_MX_INCLUDE_DIRS})
   set(GLEW_LIBRARY ${GLEW_MX_LIBRARIES})
 else()
   set(GLEW_VERSION 1.6.0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,14 @@ include_directories(
   ${CMAKE_SOURCE_DIR} # some tests need private headers
   )
 
+if(GLEW_MX_FOUND)
+  include_directories(BEFORE SYSTEM ${GLEW_MX_INCLUDE_DIRS})
+  set(GLEW_LIBRARY ${GLEW_MX_LIBRARIES})
+else()
+  set(GLEW_LIBRARY "GLEW_MX-Equalizer")
+  add_definitions(-DGLEW_STATIC=1 -DGLEW_MX=1)
+endif()
+
 file(GLOB_RECURSE TEST_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
 set(ALL_TESTS)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -19,7 +19,7 @@ endmacro(EQ_ADD_TOOL NAME)
 include_directories(${CMAKE_SOURCE_DIR}/examples/include)
 
 if(GLEW_MX_FOUND)
-  include_directories(BEFORE SYSTEM ${GLEW_MX_INCLUDE_DIR})
+  include_directories(BEFORE SYSTEM ${GLEW_MX_INCLUDE_DIRS})
   set(GLEW_LIBRARY ${GLEW_MX_LIBRARIES})
 else()
   set(GLEW_LIBRARY "GLEW_MX-Equalizer")


### PR DESCRIPTION
also fix typos i.e. GLEW_MX_INCLUDE_DIR[S]
