### PR TITLE
Notify application properly of disconnect event.

### DIFF
--- a/libs/co/rdmaConnection.h
+++ b/libs/co/rdmaConnection.h
@@ -233,6 +233,7 @@ private:
     struct rdma_cm_id *_cm_id;
     struct rdma_conn_param _conn_param;
     bool _established;
+    bool _disconnected;
     uint32_t _depth;
 
     struct ibv_device_attr _dev_attr;


### PR DESCRIPTION
Closing an event fd does not wake up poll/select/etc - need to set
a disconnected flag and write an extra "signal" so the application
will wake up and attempt a read.  Reads must then check that the
available byte(s) are indeed valid and error out if not.

[ ] May break build
[ ] May break existing applications (see CHANGES.txt)
[x] Bugfix
[ ] New Feature
[ ] Cleanup
[ ] Optimization
[ ] Documentation
