### PR TITLE
Fix remote memory region pointer tracking.

### DIFF
--- a/libs/co/global.cpp
+++ b/libs/co/global.cpp
@@ -74,7 +74,7 @@ int32_t     _iAttributes[Global::IATTR_ALL] =
     524288, // UDP_BUFFER_SIZE
     1,      // QUEUE_MIN_SIZE
     2,      // QUEUE_MAX_SIZE
-    16384,  // RDMA_RING_BUFFER_SIZE_MB
+    16,     // RDMA_RING_BUFFER_SIZE_MB
     5000,   // RDMA_RESOLVE_TIMEOUT_MS
 };
 }

--- a/libs/co/rdmaConnection.h
+++ b/libs/co/rdmaConnection.h
@@ -176,7 +176,6 @@ private:
     void _handleMsg( RDMAMessage &message );
 
     // application read/write services
-    uint32_t _makeImm( );
     void _fillFC( RDMAFCPayload &fc );
     void _fillParams( RDMAParamsPayload &params );
 
@@ -267,10 +266,9 @@ private:
         // TAIL   : advanced by application while posting FC
 
     /* local "view" of remote sink MR */
-    Ring<uint32_t, 3> _rptr;
+    Ring<uint32_t, 2> _rptr;
         //        : initialized by event thread on receipt of setup message
         // HEAD   : advanced by application while posting RDMA write
-        // MIDDLE : advanced by event thread after completing RDMA write
         // TAIL   : advanced by event thread on receipt of remote FC
 
     /* remote sink MR parameters */


### PR DESCRIPTION
Address three problems: 1) sender was not checking the right pointer in
determining receiver flow control and 2) missing ntohl corresponding to
remote htonl in the the flow control value sent by the receiver and 3)
1024 is one _KB_ not one _MB_.

[ ] May break build
[ ] May break existing applications (see CHANGES.txt)
[x] Bugfix
[ ] New Feature
[ ] Cleanup
[ ] Optimization
[ ] Documentation
