### PR TITLE
Added a config flag to choose the default load equalizer mode.

### DIFF
--- a/eq/client/init.cpp
+++ b/eq/client/init.cpp
@@ -148,6 +148,14 @@ bool _parseArguments( const int argc, char** argv )
     configFlags["multiprocess_db"] = fabric::ConfigParams::FLAG_MULTIPROCESS_DB;
     configFlags["ethernet"] = fabric::ConfigParams::FLAG_NETWORK_ETHERNET;
     configFlags["infiniband"] = fabric::ConfigParams::FLAG_NETWORK_INFINIBAND;
+    configFlags["eq_horizontal"] =
+        fabric::ConfigParams::FLAG_LOAD_EQ_HORIZONTAL;
+    configFlags["eq_vertical"] =
+        fabric::ConfigParams::FLAG_LOAD_EQ_VERTICAL;
+    configFlags["eq_2D"] =
+        fabric::ConfigParams::FLAG_LOAD_EQ_2D;
+    configFlags["eq_DB"] =
+        fabric::ConfigParams::FLAG_LOAD_EQ_DB;
 
     arg::options_description options( "Equalizer library options" );
     options.add_options()

--- a/eq/fabric/configParams.cpp
+++ b/eq/fabric/configParams.cpp
@@ -35,11 +35,32 @@ class ConfigParams
 {
 public:
     ConfigParams()
-            : renderClient( co::Global::getProgramName( ))
-            , workDir( co::Global::getWorkDir( ))
-            , flags( eq::fabric::Global::getFlags( ))
-            , prefixes( eq::fabric::Global::getPrefixes( ))
-        {}
+        : renderClient( co::Global::getProgramName( ))
+        , workDir( co::Global::getWorkDir( ))
+        , flags( eq::fabric::Global::getFlags( ))
+        , prefixes( eq::fabric::Global::getPrefixes( ))
+    {
+        if( ( flags & fabric::ConfigParams::FLAG_LOAD_EQ_ALL ) == 0 )
+            return;
+
+        switch( flags & fabric::ConfigParams::FLAG_LOAD_EQ_ALL )
+        {
+            case fabric::ConfigParams::FLAG_LOAD_EQ_2D :
+                equalizer.setMode( fabric::Equalizer::MODE_2D );
+                break;
+            case fabric::ConfigParams::FLAG_LOAD_EQ_HORIZONTAL :
+                equalizer.setMode( fabric::Equalizer::MODE_HORIZONTAL );
+                break;
+            case fabric::ConfigParams::FLAG_LOAD_EQ_VERTICAL :
+                equalizer.setMode( fabric::Equalizer::MODE_VERTICAL );
+                break;
+            case fabric::ConfigParams::FLAG_LOAD_EQ_DB :
+                equalizer.setMode( fabric::Equalizer::MODE_DB );
+                break;
+            default:
+                LBUNIMPLEMENTED;
+        }
+    }
 
     std::string renderClient;
     std::string workDir;

--- a/eq/fabric/configParams.h
+++ b/eq/fabric/configParams.h
@@ -53,7 +53,16 @@ namespace detail { class ConfigParams; }
             FLAG_MULTIPROCESS_DB = LB_BIT2, //!< one node per DB decomposition
             FLAG_NETWORK_ETHERNET = LB_BIT3, //!< Auto-config: use ethernet only
             FLAG_NETWORK_INFINIBAND = LB_BIT4, //!< Auto-config: use IB only
+            /** Auto-config: horizontal partition for load equalizer */
+            FLAG_LOAD_EQ_HORIZONTAL = LB_BIT5,
+            /** Auto-config: vertical partition for load equalizer */
+            FLAG_LOAD_EQ_VERTICAL = LB_BIT6,
+            /** Auto-config: 2D partition for load equalizer */
+            FLAG_LOAD_EQ_2D = FLAG_LOAD_EQ_HORIZONTAL | FLAG_LOAD_EQ_VERTICAL,
+            /** Auto-config: DB partition for load equalizer */
+            FLAG_LOAD_EQ_DB = LB_BIT7,
             /** @internal */
+            FLAG_LOAD_EQ_ALL = FLAG_LOAD_EQ_2D | FLAG_LOAD_EQ_DB,
             FLAG_NETWORK_ALL = FLAG_NETWORK_ETHERNET | FLAG_NETWORK_INFINIBAND
         };
 

--- a/eq/fabric/equalizer.cpp
+++ b/eq/fabric/equalizer.cpp
@@ -18,6 +18,9 @@
 
 #include "equalizer.h"
 
+#include "configParams.h"
+#include "global.h"
+
 #include <co/dataOStream.h>
 #include <co/dataIStream.h>
 
@@ -42,7 +45,30 @@ public:
         , tilesize( 64, 64 )
         , mode( fabric::Equalizer::MODE_2D )
         , frozen( false )
-    {}
+    {
+        uint32_t flags = eq::fabric::Global::getFlags( );
+
+        if( ( flags & fabric::ConfigParams::FLAG_LOAD_EQ_ALL ) == 0 )
+            return;
+
+        switch( flags & fabric::ConfigParams::FLAG_LOAD_EQ_ALL )
+        {
+            case fabric::ConfigParams::FLAG_LOAD_EQ_2D :
+                mode = fabric::Equalizer::MODE_2D;
+                break;
+            case fabric::ConfigParams::FLAG_LOAD_EQ_HORIZONTAL :
+                mode = fabric::Equalizer::MODE_HORIZONTAL;
+                break;
+            case fabric::ConfigParams::FLAG_LOAD_EQ_VERTICAL :
+                mode = fabric::Equalizer::MODE_VERTICAL;
+                break;
+            case fabric::ConfigParams::FLAG_LOAD_EQ_DB :
+                mode = fabric::Equalizer::MODE_DB;
+                break;
+            default:
+                LBUNIMPLEMENTED;
+        }
+    }
 
     Equalizer( const Equalizer& rhs )
         : damping( rhs.damping )


### PR DESCRIPTION
Mainly to be able to choose horizontal splits for Dynamic2D.
Tested for auto config as well as config files which don't specify any mode.
