### PR TITLE
Alpha value wrong in eq::util::Accum::display

### DIFF
--- a/eq/util/accumBufferObject.cpp
+++ b/eq/util/accumBufferObject.cpp
@@ -1,4 +1,3 @@
-
 /* Copyright (c) 2009-2010, Stefan Eilemann <eile@equalizergraphics.com>
  *               2009, Sarah Amsellem <sarah.amsellem@gmail.com>
  *
@@ -113,7 +112,7 @@ void AccumBufferObject::_drawQuadWithTexture( Texture* texture,
     texture->applyWrap();
     texture->applyZoomFilter( FILTER_NEAREST );
 
-    glColor3f( value, value, value );
+    glColor4f( value, value, value, value );
 
     const float startX = static_cast< float >( pvp.x );
     const float endX   = static_cast< float >( pvp.x + pvp.w );


### PR DESCRIPTION
The change is needed to capture final frames with correct alpha values (otherwise it's accumulated instead of averaged).
