### PR TITLE
Fix: https://github.com/Eyescale/Equalizer/issues/275

### DIFF
--- a/tests/client/dumpImage.cpp
+++ b/tests/client/dumpImage.cpp
@@ -89,7 +89,13 @@ int main( const int argc, char** argv )
 
     eq::fabric::ConfigParams configParams;
     eq::Config* config = server->chooseConfig( configParams );
-    TEST( config );
+
+    if( !config ) // Most probably no GPUs present, tests in meaningless
+    {
+        client->disconnectServer( server );
+        client->exitLocal();
+        return EXIT_SUCCESS;
+    }
     TEST( config->init( co::uint128_t( )));
 
     // 3.- Force frame generation


### PR DESCRIPTION
Following what other tests do: do not execute dump Image tests if not GPUs available. 

Tested on a headless local Virtual Machine. 
