### PR TITLE
Added support for specifying sensor id and axis transform for VRPN devices to eqc files.

### DIFF
--- a/eq/fabric/files.cmake
+++ b/eq/fabric/files.cmake
@@ -51,6 +51,7 @@ set(EQ_FABRIC_PUBLIC_HEADERS
   view.h
   viewport.h
   vmmlib.h
+  vrpnTracker.h
   wall.h
   windowSettings.h
   window.h
@@ -93,6 +94,7 @@ set(EQ_FABRIC_SOURCES
   subPixel.cpp
   swapBarrier.cpp
   viewport.cpp
+  vrpnTracker.cpp
   wall.cpp
   windowSettings.cpp
   zoom.cpp

--- a/eq/fabric/observer.h
+++ b/eq/fabric/observer.h
@@ -21,6 +21,7 @@
 #include <eq/fabric/api.h>
 #include <eq/fabric/eye.h>           // enum
 #include <eq/fabric/focusMode.h>     // enum
+#include <eq/fabric/vrpnTracker.h>   // enum and class
 #include <eq/fabric/object.h>        // base class
 #include <eq/fabric/types.h>
 #include <string>
@@ -97,10 +98,23 @@ namespace fabric
         int32_t getOpenCVCamera() const { return _data.camera; }
 
         /** Set the VRPN tracker device. @version 1.5.2 */
-        EQFABRIC_INL void setVRPNTracker( const std::string& index );
+        EQFABRIC_INL void setVRPNTracker( const std::string& tracker );
+
+        /** Set the VRPN tracker device sensor id. */
+        EQFABRIC_INL void setVRPNTrackerSensor( const int32_t sensor );
+
+        /** Set the VRPN tracker device axis swizzle. */
+        EQFABRIC_INL void setVRPNTrackerAxis( const VRPNTrackerAxis& axis );
 
         /** @return the current VRPN tracker device name. @version 1.5.2 */
         const std::string& getVRPNTracker() const { return _data.vrpnTracker; }
+
+        /** @return the current VRPN tracker device sensor if. */
+        int32_t getVRPNTrackerSensor() const { return _data.vrpnTrackerSensor; }
+
+        /** @return the current VRPN tracker device axis swizzle. */
+        const VRPNTrackerAxis& getVRPNTrackerAxis() const
+                                              { return _data.vrpnTrackerAxis; }
 
         /** @return the parent config of this observer. @version 1.0 */
         const C* getConfig() const { return _config; }
@@ -175,6 +189,8 @@ namespace fabric
             FocusMode focusMode; //!< The current focal distance mode
             int32_t camera; //!< The OpenCV camera used for head tracking
             std::string vrpnTracker; //!< VRPN tracking device
+            int32_t vrpnTrackerSensor; //!< VRPN tracking device sensor id
+            VRPNTrackerAxis vrpnTrackerAxis; //!< VRPN tracking axis swizzle
         }
             _data, _backup;
 

--- a/eq/fabric/observer.ipp
+++ b/eq/fabric/observer.ipp
@@ -57,6 +57,10 @@ Observer< C, O >::BackupData::BackupData()
     , focusDistance( 1.f )
     , focusMode( FOCUSMODE_FIXED )
     , camera( OFF )
+    , vrpnTracker()
+    , vrpnTrackerSensor(VRPNTrackerSensor::UseLowestValidSensorID)
+    , vrpnTrackerAxis()
+
 {
     for( size_t i = 0; i < NUM_EYES; ++i )
         eyePosition[ i ] = Vector3f::ZERO;
@@ -93,7 +97,9 @@ void Observer< C, O >::serialize( co::DataOStream& os,
     if( dirtyBits & DIRTY_FOCUS )
         os << _data.focusDistance << _data.focusMode;
     if( dirtyBits & DIRTY_TRACKER )
-        os << _data.camera << _data.vrpnTracker;
+        os << _data.camera
+           << _data.vrpnTracker
+           << _data.vrpnTrackerSensor << _data.vrpnTrackerAxis;
 }
 
 template< typename C, typename O >
@@ -110,7 +116,9 @@ void Observer< C, O >::deserialize( co::DataIStream& is,
     if( dirtyBits & DIRTY_FOCUS )
         is >> _data.focusDistance >> _data.focusMode;
     if( dirtyBits & DIRTY_TRACKER )
-        is >> _data.camera >> _data.vrpnTracker;
+        is >> _data.camera
+           >> _data.vrpnTracker
+           >> _data.vrpnTrackerSensor >> _data.vrpnTrackerAxis;
 }
 
 template< typename C, typename O >
@@ -223,6 +231,27 @@ void Observer< C, O >::setVRPNTracker( const std::string& tracker )
 }
 
 template< typename C, typename O >
+void Observer< C, O >::setVRPNTrackerSensor( const int32_t sensor )
+{
+    if( _data.vrpnTrackerSensor == sensor )
+        return;
+
+    _data.vrpnTrackerSensor = sensor;
+    setDirty( DIRTY_TRACKER );
+}
+
+template< typename C, typename O >
+void Observer< C, O >::setVRPNTrackerAxis( const VRPNTrackerAxis& axis )
+{
+    if( _data.vrpnTrackerAxis == axis )
+        return;
+
+    _data.vrpnTrackerAxis = axis;
+    setDirty( DIRTY_TRACKER );
+}
+
+
+template< typename C, typename O >
 bool Observer< C, O >::setHeadMatrix( const Matrix4f& matrix )
 {
     if( _data.headMatrix == matrix )
@@ -252,8 +281,15 @@ std::ostream& operator << ( std::ostream& os, const Observer< C, O >& observer )
        << "opencv_camera  " << IAttribute( observer.getOpenCVCamera( ))
        << std::endl;
     if( !observer.getVRPNTracker().empty( ))
-        os << "vrpn_tracker   \"" << observer.getVRPNTracker() << "\""
+    {
+        os << "vrpn_tracker        \"" << observer.getVRPNTracker() << "\""
            << std::endl;
+        os << "vrpn_tracker_sensor "
+           << VRPNTrackerSensor::SensorID(observer.getVRPNTrackerSensor())
+           << std::endl;
+        os << "vrpn_tracker_axis   " << observer.getVRPNTrackerAxis()
+           << std::endl;
+    }
     os << lunchbox::exdent << "}" << std::endl << lunchbox::enableHeader
        << lunchbox::enableFlush;
     return os;

--- a/eq/fabric/vmmlib.h
+++ b/eq/fabric/vmmlib.h
@@ -93,7 +93,24 @@ template<> inline void byteswap( eq::fabric::Vector4i& value )
 template<> inline void byteswap( eq::fabric::Vector4ub& ) { /*NOP*/ }
 template<> inline void byteswap( eq::fabric::Vector3ub& ) { /*NOP*/ }
 
+template<> inline void byteswap( eq::fabric::Matrix3f& value )
+{
+    for( size_t i = 0; i < value.size(); ++i )
+        byteswap( value.array[ i ]);
+}
+
+template<> inline void byteswap( eq::fabric::Matrix3d& value )
+{
+    for( size_t i = 0; i < value.size(); ++i )
+        byteswap( value.array[ i ]);
+}
 template<> inline void byteswap( eq::fabric::Matrix4f& value )
+{
+    for( size_t i = 0; i < 16; ++i )
+        byteswap( value.array[ i ]);
+}
+
+template<> inline void byteswap( eq::fabric::Matrix4d& value )
 {
     for( size_t i = 0; i < 16; ++i )
         byteswap( value.array[ i ]);

--- a/eq/fabric/vrpnTracker.cpp
+++ b/eq/fabric/vrpnTracker.cpp
@@ -1,0 +1,111 @@
+
+/* Copyright (c) 2014-2014, Stefan Eilemann <eile@equalizergraphics.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "vrpnTracker.h"
+
+#include <string>
+#include <map>
+
+#include <boost/regex.hpp>
+#include <boost/assign.hpp>
+
+namespace eq
+{
+namespace fabric
+{
+std::ostream& operator << ( std::ostream& os,
+                            const VRPNTrackerSensor::SensorID value )
+{
+    switch( value )
+    {
+        case VRPNTrackerSensor::UseAnyValidSensorID:    os << "ANY"; break;
+        case VRPNTrackerSensor::UseLowestValidSensorID: os << "LOWEST"; break;
+        default:        os << static_cast< int >( value );
+    }
+    return os;
+}
+
+
+VRPNTrackerAxis::VRPNTrackerAxis() :
+    _transform( Matrix4f::IDENTITY )
+{
+    _transform(2,2) = -1.f; // TODO: remove old default; specify explicitly
+}
+
+VRPNTrackerAxis::VRPNTrackerAxis(const VRPNTrackerAxis& axis)
+{
+    _transform = axis._transform;
+}
+
+VRPNTrackerAxis::VRPNTrackerAxis(   const Vector3f& x,
+                                    const Vector3f& y,
+                                    const Vector3f& z) :
+    _transform()
+{
+    _transform.set_row(0, x);
+    _transform.set_row(1, y);
+    _transform.set_row(2, z);
+}
+
+VRPNTrackerAxis::VRPNTrackerAxis(const std::string& axis) :
+    _transform( Matrix4f::IDENTITY )
+{
+    _transform(2,2) = -1.f; // TODO: remove old default; specify explicitly
+
+    if (!axis.empty())
+    {
+        if (!parseTransform(axis, _transform))
+            LBWARN << "VRPN tracker couldn't process axis option: " << axis;
+    }
+}
+
+bool VRPNTrackerAxis::operator==(const VRPNTrackerAxis& axis ) const
+{
+    return _transform == axis._transform;
+}
+
+bool VRPNTrackerAxis::parseTransform(const std::string& axis,
+                           Matrix3f& transformOut )
+{
+    static const boost::regex k_axis_re("^([xyzXYZ])([xyzXYZ])([xyzXYZ])$");
+    static std::map<char,Vector3f> k_axisMap =
+            boost::assign::map_list_of ('X', Vector3f::UNIT_X)
+                                       ('Y', Vector3f::UNIT_Y)
+                                       ('Z', Vector3f::UNIT_Z);
+
+    boost::smatch optResult;
+    if (boost::regex_search(axis, optResult, k_axis_re))
+    {
+        for (size_t r = 0; r < transformOut.ROWS; ++r)
+        {
+            std::string optionValue(optResult.str(r+1));
+            LBASSERT(optionValue.size() == 1);
+            const char ax = optionValue[0];
+            const float scale = std::isupper(ax) ? 1.f : -1.f;
+            const Vector3f v = scale * k_axisMap[std::toupper(ax)];
+
+            transformOut.set_row(r, v);
+        }
+    }
+    else
+        return false;
+
+    return true;
+}
+
+}
+}

--- a/eq/fabric/vrpnTracker.h
+++ b/eq/fabric/vrpnTracker.h
@@ -1,0 +1,114 @@
+
+/* Copyright (c) 2014-2014, Stefan Eilemann <eile@equalizergraphics.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef EQFABRIC_VRPNTRACKER_H
+#define EQFABRIC_VRPNTRACKER_H
+
+#include <eq/fabric/api.h>
+#include <eq/fabric/vmmlib.h>
+#include <lunchbox/debug.h>
+#include <lunchbox/bitOperation.h>
+#include <iostream>
+
+namespace eq
+{
+namespace fabric
+{
+    /** Special VRPN Sensor ID values */
+    struct VRPNTrackerSensor
+    {
+        enum SensorID
+        {
+            UseAnyValidSensorID = -1,
+            UseLowestValidSensorID = -2
+        };
+    };
+
+    EQFABRIC_API std::ostream& operator << ( std::ostream& os,
+                                const VRPNTrackerSensor::SensorID value );
+
+    /** Specification of an axis swizzle. */
+    class VRPNTrackerAxis
+    {
+    public:
+
+        /** @name Constructors */
+        //@{
+        /** Construct a new default axis transform. */
+        VRPNTrackerAxis();
+
+        /** Copy Construct a new axis from existing axis. */
+        VRPNTrackerAxis(const VRPNTrackerAxis& axis);
+
+        /** Construct a new axis transform from X Y Z vectors. */
+        VRPNTrackerAxis(const Vector3f& x, const Vector3f& y, const Vector3f& z);
+
+        /** Construct a new axis transform from string representation. */
+        VRPNTrackerAxis(const std::string& axis);
+
+        //@}
+
+        /** @name Data Access */
+        //@{
+        /** @return return coordinate transform. */
+        const Matrix3f& getTransform() const { return _transform; }
+        /** @return return coordinate transform. */
+        Matrix3f& getTransform() { return _transform; }
+
+        bool operator==(const VRPNTrackerAxis& axis ) const;
+
+        //@}
+
+        /** @name Utilities */
+        //@{
+        /** @return parse axis string into transform; return true if
+         * successful (transform fully initialized), false otherwise.
+         */
+        static bool parseTransform(const std::string& axis,
+                                   Matrix3f& transformOut );
+
+        //@}
+
+    protected:
+
+        Matrix3f _transform;        //!< Axis transform
+    };
+
+
+    inline std::ostream& operator << ( std::ostream& os,
+                                       const VRPNTrackerAxis& axis )
+    {
+        const Matrix3f& t(axis.getTransform());
+
+        os << "[ "
+           << "[ " << t(0,0) << " " << t(0,1) << " " << t(0,2) << "] "
+           << "[ " << t(1,0) << " " << t(1,1) << " " << t(1,2) << "] "
+           << "[ " << t(2,0) << " " << t(2,1) << " " << t(2,2) << "] "
+           << "]";
+        return os;
+    }
+}
+}
+
+namespace lunchbox
+{
+template<> inline void byteswap( eq::fabric::VRPNTrackerAxis& value )
+{
+    byteswap( value.getTransform() );
+}
+}
+#endif // EQFABRIC_VRPNTRACKER_H

--- a/eq/server/loader.l
+++ b/eq/server/loader.l
@@ -230,6 +230,11 @@ focus_distance                  { return EQTOKEN_FOCUS_DISTANCE; }
 focus_mode                      { return EQTOKEN_FOCUS_MODE; }
 opencv_camera                   { return EQTOKEN_OPENCV_CAMERA; }
 vrpn_tracker                    { return EQTOKEN_VRPN_TRACKER; }
+vrpn_tracker_sensor             { return EQTOKEN_VRPN_TRACKER_SENSOR; }
+ANY                             { return EQTOKEN_ANY; }
+LOWEST                          { return EQTOKEN_LOWEST; }
+vrpn_tracker_axis               { return EQTOKEN_VRPN_TRACKER_AXIS; }
+[xyzXYZ]{3}                     { return EQTOKEN_VRPN_AXIS; }
 robustness                      { return EQTOKEN_ROBUSTNESS; }
 buffer                          { return EQTOKEN_BUFFER; }
 CLEAR                           { return EQTOKEN_CLEAR; }
@@ -297,12 +302,11 @@ STEREO                          { return EQTOKEN_STEREO; }
 size                            { return EQTOKEN_SIZE; }
 DisplayCluster                  { return EQTOKEN_DISPLAYCLUSTER; }
 dump_image                      { return EQTOKEN_DUMP_IMAGE; }
-
 [+-]?[0-9]+[\.][0-9]*           { return EQTOKEN_FLOAT; }
 [+-]?[0-9]*[\.][0-9]+           { return EQTOKEN_FLOAT; }
 [+]?[0-9]+                      { return EQTOKEN_UNSIGNED; }
 [+-]?[0-9]+                     { return EQTOKEN_INTEGER; }
-\"[-\\\., _%&@<>:a-zA-Z0-9\! \/]*\"  { return EQTOKEN_STRING; }
+\"[-\\\., =_%&@<>:a-zA-Z0-9\! \/]*\"  { return EQTOKEN_STRING; }
 '.'                             { return EQTOKEN_CHARACTER; }
 
 [\(\){}\[\]]                    { return *yytext; }

--- a/eq/server/loader.y
+++ b/eq/server/loader.y
@@ -231,6 +231,11 @@
 %token EQTOKEN_FOCUS_MODE
 %token EQTOKEN_OPENCV_CAMERA
 %token EQTOKEN_VRPN_TRACKER
+%token EQTOKEN_VRPN_TRACKER_SENSOR
+%token EQTOKEN_ANY
+%token EQTOKEN_LOWEST
+%token EQTOKEN_VRPN_TRACKER_AXIS
+%token EQTOKEN_VRPN_AXIS
 %token EQTOKEN_ROBUSTNESS
 %token EQTOKEN_THREAD_MODEL
 %token EQTOKEN_ASYNC
@@ -315,7 +320,7 @@
     float                   _viewport[4];
 }
 
-%type <_string>           STRING;
+%type <_string>           STRING VRPN_AXIS;
 %type <_character>        CHARACTER;
 %type <_int>              INTEGER IATTR;
 %type <_unsigned>         UNSIGNED colorMask colorMaskBit colorMaskBits;
@@ -799,6 +804,33 @@ observerField:
         { observer->setFocusMode( eq::fabric::FocusMode( $2 )); }
     | EQTOKEN_OPENCV_CAMERA IATTR { observer->setOpenCVCamera( $2 ); }
     | EQTOKEN_VRPN_TRACKER STRING { observer->setVRPNTracker( $2 ); }
+    | EQTOKEN_VRPN_TRACKER_SENSOR INTEGER { observer->setVRPNTrackerSensor( $2 ); }
+    | EQTOKEN_VRPN_TRACKER_SENSOR EQTOKEN_ANY
+    {
+        observer->setVRPNTrackerSensor( eq::fabric::VRPNTrackerSensor::
+                                        UseAnyValidSensorID );
+    }
+    | EQTOKEN_VRPN_TRACKER_SENSOR EQTOKEN_LOWEST
+    {
+        observer->setVRPNTrackerSensor( eq::fabric::VRPNTrackerSensor::
+                                        UseAnyValidSensorID );
+    }
+    | EQTOKEN_VRPN_TRACKER_AXIS VRPN_AXIS
+    {
+        observer->setVRPNTrackerAxis( eq::fabric::VRPNTrackerAxis($2) );
+    }
+    | EQTOKEN_VRPN_TRACKER_AXIS '[' '[' FLOAT FLOAT FLOAT ']'
+                                    '[' FLOAT FLOAT FLOAT ']'
+                                    '[' FLOAT FLOAT FLOAT ']' ']'
+    {
+        observer->setVRPNTrackerAxis( eq::fabric::VRPNTrackerAxis(
+            eq::fabric::Vector3f( $4, $5, $6 ),
+            eq::fabric::Vector3f( $9, $10, $11 ),
+            eq::fabric::Vector3f( $14, $15, $16 )) );
+    }
+
+VRPN_AXIS: EQTOKEN_VRPN_AXIS               { $$ = yytext; }
+
 
 layout: EQTOKEN_LAYOUT '{' { layout = new eq::server::Layout( config ); }
             layoutFields '}' { layout = 0; }
@@ -1415,6 +1447,7 @@ FLOAT: EQTOKEN_FLOAT                       { $$ = atof( yytext ); }
 INTEGER: EQTOKEN_INTEGER                   { $$ = atoi( yytext ); }
     | UNSIGNED                             { $$ = $1; }
 UNSIGNED: EQTOKEN_UNSIGNED                 { $$ = atoi( yytext ); }
+
 %%
 
 namespace eq


### PR DESCRIPTION
Added support to specify the sensor id of the tracker (there may be multiple sensors on at the same address).
The default is to gracefully find and use the lowest active sensor.
Specify vrpn_tracker_sensor as: ANY, LOWEST, or sensor id integer
Added support to specify a tracker to eq-space transformation, as either a matrix or axis string.
Specify vrpn_tracker_axis as: [[FLOAT FLOAT FLOAT][FLOAT FLOAT FLOAT][FLOAT FLOAT FLOAT]] where
each vector represents the X, Y, and Z tracker axis
Or as an axis string (regex): [XYZxyz]{3} where lowercase denotes negative, uppercase positive
E.g., These two representations are equivalent (map X to X, Y to -Z, and Z to Y):
[[1 0 0][0 0 -1][0 1 0]] == XzY
Added more debug info; now using scoped_ptr