### PR TITLE
Implement support for OpenGL core context creation (#156)

### DIFF
--- a/eq/client/compositor.h
+++ b/eq/client/compositor.h
@@ -314,8 +314,22 @@ namespace eq
         /**
          * draw an image to the frame buffer using a texture quad or drawPixels.
          */
-        static void _drawPixels( const Image* image, const ImageOp& op,
-                                 const Frame::Buffer which );
+        static void _drawPixelsFF( const Image* image, const ImageOp& op,
+                                   const Frame::Buffer which );
+
+        static void _drawPixelsGLSL( const Image* image, const ImageOp& op,
+                                     const Frame::Buffer which );
+
+        static bool _setupDrawPixels( const Image* image, const ImageOp& op,
+                                      const Frame::Buffer which );
+
+        static Vector4f _getCoords( const ImageOp& op,
+                                    const PixelViewport& pvp );
+
+        template< typename T >
+        static void _drawTexturedQuad( const T* key,const ImageOp& op,
+                                       const PixelViewport& pvp,
+                                       const bool withDepth );
 
         /** @return the accumulation buffer used for subpixel compositing. */
         static util::Accum* _obtainAccum( Channel* channel );

--- a/eq/client/compressor/compressorReadDrawPixels.cpp
+++ b/eq/client/compressor/compressorReadDrawPixels.cpp
@@ -300,21 +300,33 @@ void _copy4( eq_uint64_t dst[4], const eq_uint64_t src[4] )
 void _initPackAlignment( const eq_uint64_t width )
 {
     if( (width % 4) == 0 )
-        glPixelStorei( GL_PACK_ALIGNMENT, 4 );
+    {
+        EQ_GL_CALL( glPixelStorei( GL_PACK_ALIGNMENT, 4 ));
+    }
     else if( (width % 2) == 0 )
-        glPixelStorei( GL_PACK_ALIGNMENT, 2 );
+    {
+        EQ_GL_CALL( glPixelStorei( GL_PACK_ALIGNMENT, 2 ));
+    }
     else
-        glPixelStorei( GL_PACK_ALIGNMENT, 1 );
+    {
+        EQ_GL_CALL( glPixelStorei( GL_PACK_ALIGNMENT, 1 ));
+    }
 }
 
 void _initUnpackAlignment( const eq_uint64_t width )
 {
     if( (width % 4) == 0 )
-        glPixelStorei( GL_UNPACK_ALIGNMENT, 4 );
+    {
+        EQ_GL_CALL( glPixelStorei( GL_UNPACK_ALIGNMENT, 4 ));
+    }
     else if( (width % 2) == 0 )
-        glPixelStorei( GL_UNPACK_ALIGNMENT, 2 );
+    {
+        EQ_GL_CALL( glPixelStorei( GL_UNPACK_ALIGNMENT, 2 ));
+    }
     else
-        glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
+    {
+        EQ_GL_CALL( glPixelStorei( GL_UNPACK_ALIGNMENT, 1 ));
+    }
 }
 }
 
@@ -416,8 +428,9 @@ void CompressorReadDrawPixels::upload( const GLEWContext* glewContext,
 
     if( flags & EQ_COMPRESSOR_USE_FRAMEBUFFER )
     {
-        glRasterPos2i( outDims[0], outDims[2] );
-        glDrawPixels( outDims[1], outDims[3], _format, _type, buffer );
+        EQ_GL_CALL( glRasterPos2i( outDims[0], outDims[2] ));
+        EQ_GL_CALL( glDrawPixels( outDims[1], outDims[3], _format, _type,
+                    buffer ));
     }
     else
     {

--- a/eq/client/glx/pipe.cpp
+++ b/eq/client/glx/pipe.cpp
@@ -1,7 +1,7 @@
 
-/* Copyright (c) 2005-2014, Stefan Eilemann <eile@equalizergraphics.com>
- *                    2009, Maxim Makhinya
- *                    2010, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2005-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Maxim Makhinya
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -125,7 +125,6 @@ void Pipe::configExit()
     XCloseDisplay( xDisplay );
     LBVERB << "Closed X display " << xDisplay << std::endl;
 }
-
 
 std::string Pipe::getXDisplayString()
 {
@@ -261,6 +260,10 @@ bool Pipe::_configInitGLXEW()
     {
         LBVERB << "Pipe GLXEW initialization successful" << std::endl;
         success = configInitGL();
+
+        const char* glVersion = (const char*)glGetString( GL_VERSION );
+        if( success && glVersion )
+            _maxOpenGLVersion = static_cast<float>( atof( glVersion ));
     }
     else
         sendError( ERROR_GLXPIPE_GLXEWINIT_FAILED )

--- a/eq/client/qt/widgetFactory.cpp
+++ b/eq/client/qt/widgetFactory.cpp
@@ -1,6 +1,6 @@
 
-/* Copyright (c) 2014, Daniel Nachbaur <danielnachbaur@gmail.com>
- *               2014, Stefan.Eilemann@epfl.ch
+/* Copyright (c) 2014-2015, Daniel Nachbaur <danielnachbaur@gmail.com>
+ *                          Stefan.Eilemann@epfl.ch
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -37,6 +37,14 @@ QGLFormat _createQGLFormat( const WindowSettings& settings )
 {
     // defaults: http://qt-project.org/doc/qt-4.8/qglformat.html#QGLFormat
     QGLFormat format;
+
+    const int coreProfile = getAttribute( IATTR_HINT_CORE_PROFILE );
+    if( coreProfile == ON )
+    {
+        format.setVersion( getAttribute( IATTR_HINT_OPENGL_MAJOR ),
+                           getAttribute( IATTR_HINT_OPENGL_MINOR ) );
+        format.setProfile( QGLFormat::CoreProfile );
+    }
 
     const int colorSize = getAttribute( IATTR_PLANES_COLOR );
     if( colorSize > 0 || colorSize == eq::AUTO )

--- a/eq/client/roiFinder.cpp
+++ b/eq/client/roiFinder.cpp
@@ -32,6 +32,7 @@
 
 #include <eq/util/frameBufferObject.h>
 #include <eq/util/objectManager.h>
+#include <eq/util/shader.h>
 #include <lunchbox/os.h>
 #include <pression/plugins/compressor.h>
 
@@ -600,20 +601,13 @@ void ROIFinder::_readbackInfo( util::ObjectManager& glObjects )
 #else
         const GLchar* fShaderPtr = roiFragmentShaderRGB_glsl.c_str();
 #endif
-        EQ_GL_CALL( glShaderSource( shader, 1, &fShaderPtr, 0 ));
-        EQ_GL_CALL( glCompileShader( shader ));
-
-        GLint status;
-        glGetShaderiv( shader, GL_COMPILE_STATUS, &status );
-        if( !status )
-            LBERROR << "Failed to compile fragment shader for ROI finder"
-                    << std::endl;
-
+        LBCHECK( util::shader::compile( shader, fShaderPtr ));
         program = glObjects.newProgram( shaderRBInfo );
 
         EQ_GL_CALL( glAttachShader( program, shader ));
         EQ_GL_CALL( glLinkProgram( program ));
 
+        GLint status;
         glGetProgramiv( program, GL_LINK_STATUS, &status );
         if( !status )
         {

--- a/eq/client/systemPipe.cpp
+++ b/eq/client/systemPipe.cpp
@@ -1,5 +1,6 @@
 
-/* Copyright (c) 2009-2013, Stefan Eilemann <eile@equalizergraphics.com>
+/* Copyright (c) 2009-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -23,7 +24,8 @@ namespace eq
 {
 
 SystemPipe::SystemPipe( Pipe* parent )
-    : _pipe( parent )
+    : _maxOpenGLVersion( fabric::AUTO )
+    , _pipe( parent )
 {
     LBASSERT( _pipe );
 }

--- a/eq/client/systemPipe.h
+++ b/eq/client/systemPipe.h
@@ -1,6 +1,7 @@
 
-/* Copyright (c) 2009-2013, Stefan Eilemann <eile@equalizergraphics.com>
- *                    2009, Maxim Makhinya
+/* Copyright (c) 2009-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Maxim Makhinya
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -58,6 +59,10 @@ namespace eq
         /** @return the parent Pipe. @version 1.0 */
         const Pipe* getPipe() const { return _pipe; }
 
+        /** @return the maximum available OpenGL version on this pipe.
+         *  @version 1.9 */
+        float getMaxOpenGLVersion() const { return _maxOpenGLVersion; }
+
     protected:
         /** @name Error information. */
         //@{
@@ -68,6 +73,8 @@ namespace eq
          */
         EQ_API EventOCommand sendError( const uint32_t error );
         //@}
+
+        float _maxOpenGLVersion;
 
     private:
         /** The parent eq::Pipe. */

--- a/eq/client/wgl/pipe.cpp
+++ b/eq/client/wgl/pipe.cpp
@@ -294,6 +294,10 @@ bool Pipe::_configInitWGLEW()
     {
         LBINFO << "Pipe WGLEW initialization successful" << std::endl;
         success = configInitGL();
+
+        const char* glVersion = (const char*)glGetString( GL_VERSION );
+        if( success && glVersion )
+            _maxOpenGLVersion = static_cast<float>( atof( glVersion ));
     }
     else
         sendError( ERROR_WGLPIPE_WGLEWINIT_FAILED )

--- a/eq/fabric/drawableConfig.h
+++ b/eq/fabric/drawableConfig.h
@@ -1,15 +1,16 @@
 
-/* Copyright (c) 2005-2012, Stefan Eilemann <eile@equalizergraphics.com> 
+/* Copyright (c) 2005-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
  * by the Free Software Foundation.
- *  
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -29,7 +30,8 @@ namespace fabric
     {
         DrawableConfig()
                 : stencilBits(0), colorBits(0), alphaBits(0), accumBits(0)
-                , glVersion( 0.f ), stereo( false ), doublebuffered( false ) {}
+                , glVersion( 0.f ), stereo( false ), doublebuffered( false )
+                , coreProfile( false ) {}
 
         int32_t stencilBits;    //!< Number of stencil bits
         int32_t colorBits;      //!< Number of bits per color component
@@ -38,12 +40,15 @@ namespace fabric
         float   glVersion;      //!< OpenGL version
         bool    stereo;         //!< Active stereo supported
         bool    doublebuffered; //!< Doublebuffering supported
+        bool    coreProfile;    //!< Core or Compat profile (since OpenGL 3.2)
     };
 
     inline std::ostream& operator << ( std::ostream& os,
                                        const DrawableConfig& config )
     {
         os << "GL" << config.glVersion;
+        if( config.glVersion >= 3.2f )
+            os << (config.coreProfile ? "|Core" : "|Compat");
         os << "|rgb" << config.colorBits;
         if( config.alphaBits )
             os << "a" << config.alphaBits;

--- a/eq/fabric/window.ipp
+++ b/eq/fabric/window.ipp
@@ -1,7 +1,7 @@
 
-/* Copyright (c) 2010-2013, Stefan Eilemann <eile@equalizergraphics.com>
- *                    2010, Cedric Stalder <cedric.stalder@gmail.com>
- *               2010-2014, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2010-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Cedric Stalder <cedric.stalder@gmail.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -39,6 +39,9 @@ namespace
 {
 #define MAKE_WINDOW_ATTR_STRING( attr ) ( std::string("EQ_WINDOW_") + #attr )
 std::string _iAttributeStrings[] = {
+    MAKE_WINDOW_ATTR_STRING( IATTR_HINT_CORE_PROFILE ),
+    MAKE_WINDOW_ATTR_STRING( IATTR_HINT_OPENGL_MAJOR ),
+    MAKE_WINDOW_ATTR_STRING( IATTR_HINT_OPENGL_MINOR ),
     MAKE_WINDOW_ATTR_STRING( IATTR_HINT_STEREO ),
     MAKE_WINDOW_ATTR_STRING( IATTR_HINT_DOUBLEBUFFER ),
     MAKE_WINDOW_ATTR_STRING( IATTR_HINT_FULLSCREEN ),

--- a/eq/fabric/windowSettings.h
+++ b/eq/fabric/windowSettings.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 2014, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2014-2015, Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -56,6 +56,9 @@ public:
     enum IAttribute
     {
         // Note: also update string array initialization in window.ipp
+        IATTR_HINT_CORE_PROFILE,     //!< Core profile context if possible
+        IATTR_HINT_OPENGL_MAJOR,     //!< Major version for GL context creation
+        IATTR_HINT_OPENGL_MINOR,     //!< Minor version for GL context creation
         IATTR_HINT_STEREO,           //!< Active stereo
         IATTR_HINT_DOUBLEBUFFER,     //!< Front and back buffer
         IATTR_HINT_FULLSCREEN,       //!< Fullscreen drawable

--- a/eq/server/global.cpp
+++ b/eq/server/global.cpp
@@ -1,6 +1,6 @@
 
-/* Copyright (c) 2006-2013, Stefan Eilemann <eile@equalizergraphics.com>
- *               2011-2014, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2006-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -96,6 +96,9 @@ void Global::_setupDefaults()
     for( uint32_t i=0; i<WindowSettings::IATTR_ALL; ++i )
         _windowIAttributes[i] = fabric::UNDEFINED;
 
+    _windowIAttributes[WindowSettings::IATTR_HINT_CORE_PROFILE] = fabric::OFF;
+    _windowIAttributes[WindowSettings::IATTR_HINT_OPENGL_MAJOR] = fabric::AUTO;
+    _windowIAttributes[WindowSettings::IATTR_HINT_OPENGL_MINOR] = fabric::AUTO;
     _windowIAttributes[WindowSettings::IATTR_HINT_STEREO]       = fabric::AUTO;
     _windowIAttributes[WindowSettings::IATTR_HINT_DOUBLEBUFFER] = fabric::AUTO;
     _windowIAttributes[WindowSettings::IATTR_HINT_FULLSCREEN]   = fabric::OFF;

--- a/eq/server/init.cpp
+++ b/eq/server/init.cpp
@@ -1,15 +1,16 @@
 
-/* Copyright (c) 2010, Stefan Eilemann <eile@equalizergraphics.com> 
+/* Copyright (c) 2010-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
  * by the Free Software Foundation.
- *  
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -40,12 +41,12 @@ bool init( const int argc, char** argv )
 
     return fabric::init( argc, argv );
 }
-    
+
 bool exit()
 {
     if( !_initialized )
     {
-        LBERROR << "Equalizer client library not initialized" << std::endl;
+        LBERROR << "Equalizer server library not initialized" << std::endl;
         return false;
     }
     _initialized = false;

--- a/eq/server/loader.l
+++ b/eq/server/loader.l
@@ -1,6 +1,7 @@
 
 %{
-/* Copyright (c) 2006-2014, Stefan Eilemann <eile@equalizergraphics.com>
+/* Copyright (c) 2006-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -108,6 +109,9 @@ EQ_PIPE_IATTR_HINT_THREAD        { return EQTOKEN_PIPE_IATTR_HINT_THREAD; }
 EQ_PIPE_IATTR_HINT_AFFINITY      { return EQTOKEN_PIPE_IATTR_HINT_AFFINITY; }
 EQ_PIPE_IATTR_HINT_CUDA_GL_INTEROP { return EQTOKEN_PIPE_IATTR_HINT_CUDA_GL_INTEROP; }
 EQ_VIEW_SATTR_DISPLAYCLUSTER      { return EQTOKEN_VIEW_SATTR_DISPLAYCLUSTER; }
+EQ_WINDOW_IATTR_HINT_CORE_PROFILE { return EQTOKEN_WINDOW_IATTR_HINT_CORE_PROFILE; }
+EQ_WINDOW_IATTR_HINT_OPENGL_MAJOR { return EQTOKEN_WINDOW_IATTR_HINT_OPENGL_MAJOR; }
+EQ_WINDOW_IATTR_HINT_OPENGL_MINOR { return EQTOKEN_WINDOW_IATTR_HINT_OPENGL_MINOR; }
 EQ_WINDOW_IATTR_HINT_STEREO      { return EQTOKEN_WINDOW_IATTR_HINT_STEREO; }
 EQ_WINDOW_IATTR_HINT_DOUBLEBUFFER { return EQTOKEN_WINDOW_IATTR_HINT_DOUBLEBUFFER; }
 EQ_WINDOW_IATTR_HINT_FULLSCREEN  { return EQTOKEN_WINDOW_IATTR_HINT_FULLSCREEN;}
@@ -143,6 +147,9 @@ hint_doublebuffer               { return EQTOKEN_HINT_DOUBLEBUFFER; }
 hint_fullscreen                 { return EQTOKEN_HINT_FULLSCREEN; }
 hint_statistics                 { return EQTOKEN_HINT_STATISTICS; }
 hint_sendtoken                  { return EQTOKEN_HINT_SENDTOKEN; }
+hint_core_profile               { return EQTOKEN_HINT_CORE_PROFILE; }
+hint_opengl_major               { return EQTOKEN_HINT_OPENGL_MAJOR; }
+hint_opengl_minor               { return EQTOKEN_HINT_OPENGL_MINOR; }
 hint_stereo                     { return EQTOKEN_HINT_STEREO; }
 hint_swapsync                   { return EQTOKEN_HINT_SWAPSYNC; }
 hint_drawable                   { return EQTOKEN_HINT_DRAWABLE; }

--- a/eq/server/loader.y
+++ b/eq/server/loader.y
@@ -1,7 +1,7 @@
 
-/* Copyright (c) 2006-2012, Stefan Eilemann <eile@equalizergraphics.com>
- *               2008-2010, Cedric Stalder <cedric.stalder@gmail.com>
- *               2011-2014, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2006-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Cedric Stalder <cedric.stalder@gmail.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -124,6 +124,9 @@
 %token EQTOKEN_PIPE_IATTR_HINT_THREAD
 %token EQTOKEN_PIPE_IATTR_HINT_AFFINITY
 %token EQTOKEN_VIEW_SATTR_DISPLAYCLUSTER
+%token EQTOKEN_WINDOW_IATTR_HINT_CORE_PROFILE
+%token EQTOKEN_WINDOW_IATTR_HINT_OPENGL_MAJOR
+%token EQTOKEN_WINDOW_IATTR_HINT_OPENGL_MINOR
 %token EQTOKEN_WINDOW_IATTR_HINT_STEREO
 %token EQTOKEN_WINDOW_IATTR_HINT_DOUBLEBUFFER
 %token EQTOKEN_WINDOW_IATTR_HINT_FULLSCREEN
@@ -147,6 +150,9 @@
 %token EQTOKEN_PIPE
 %token EQTOKEN_WINDOW
 %token EQTOKEN_ATTRIBUTES
+%token EQTOKEN_HINT_CORE_PROFILE
+%token EQTOKEN_HINT_OPENGL_MAJOR
+%token EQTOKEN_HINT_OPENGL_MINOR
 %token EQTOKEN_HINT_STEREO
 %token EQTOKEN_HINT_DOUBLEBUFFER
 %token EQTOKEN_HINT_FULLSCREEN
@@ -418,6 +424,21 @@ global:
      {
          eq::server::Global::instance()->setPipeIAttribute(
              eq::server::Pipe::IATTR_HINT_CUDA_GL_INTEROP, $2 );
+     }
+     | EQTOKEN_WINDOW_IATTR_HINT_CORE_PROFILE IATTR
+     {
+         eq::server::Global::instance()->setWindowIAttribute(
+             eq::server::WindowSettings::IATTR_HINT_CORE_PROFILE, $2 );
+     }
+     | EQTOKEN_WINDOW_IATTR_HINT_OPENGL_MAJOR IATTR
+     {
+         eq::server::Global::instance()->setWindowIAttribute(
+             eq::server::WindowSettings::IATTR_HINT_OPENGL_MAJOR, $2 );
+     }
+     | EQTOKEN_WINDOW_IATTR_HINT_OPENGL_MINOR IATTR
+     {
+         eq::server::Global::instance()->setWindowIAttribute(
+             eq::server::WindowSettings::IATTR_HINT_OPENGL_MINOR, $2 );
      }
      | EQTOKEN_WINDOW_IATTR_HINT_STEREO IATTR
      {
@@ -700,7 +721,13 @@ windowField:
         }
 windowAttributes: /*null*/ | windowAttributes windowAttribute
 windowAttribute:
-    EQTOKEN_HINT_STEREO IATTR
+    EQTOKEN_HINT_CORE_PROFILE IATTR
+        { window->setIAttribute( eq::server::WindowSettings::IATTR_HINT_CORE_PROFILE, $2 ); }
+    | EQTOKEN_HINT_OPENGL_MAJOR IATTR
+        { window->setIAttribute( eq::server::WindowSettings::IATTR_HINT_OPENGL_MAJOR, $2 ); }
+    | EQTOKEN_HINT_OPENGL_MINOR IATTR
+        { window->setIAttribute( eq::server::WindowSettings::IATTR_HINT_OPENGL_MINOR, $2 ); }
+    | EQTOKEN_HINT_STEREO IATTR
         { window->setIAttribute( eq::server::WindowSettings::IATTR_HINT_STEREO, $2 ); }
     | EQTOKEN_HINT_DOUBLEBUFFER IATTR
         { window->setIAttribute( eq::server::WindowSettings::IATTR_HINT_DOUBLEBUFFER, $2 ); }

--- a/eq/server/window.cpp
+++ b/eq/server/window.cpp
@@ -1,6 +1,7 @@
 
-/* Copyright (c) 2005-2013, Stefan Eilemann <eile@equalizergraphics.com>
- *                    2010, Cedric Stalder <cedric.stalder@gmail.com>
+/* Copyright (c) 2005-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Cedric Stalder <cedric.stalder@gmail.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -527,37 +528,43 @@ void Window::output( std::ostream& os ) const
             attrPrinted = true;
         }
 
-        os << ( i== WindowSettings::IATTR_HINT_STEREO ?
+        os << ( i == WindowSettings::IATTR_HINT_CORE_PROFILE ?
+                    "hint_core_profile  " :
+                i == WindowSettings::IATTR_HINT_OPENGL_MAJOR ?
+                    "hint_opengl_major  " :
+                i == WindowSettings::IATTR_HINT_OPENGL_MINOR ?
+                    "hint_opengl_minor  " :
+                i == WindowSettings::IATTR_HINT_STEREO ?
                     "hint_stereo        " :
-                i== WindowSettings::IATTR_HINT_DOUBLEBUFFER ?
+                i == WindowSettings::IATTR_HINT_DOUBLEBUFFER ?
                     "hint_doublebuffer  " :
-                i== WindowSettings::IATTR_HINT_FULLSCREEN ?
+                i == WindowSettings::IATTR_HINT_FULLSCREEN ?
                     "hint_fullscreen    " :
-                i== WindowSettings::IATTR_HINT_DECORATION ?
+                i == WindowSettings::IATTR_HINT_DECORATION ?
                     "hint_decoration    " :
-                i== WindowSettings::IATTR_HINT_SWAPSYNC ?
+                i == WindowSettings::IATTR_HINT_SWAPSYNC ?
                     "hint_swapsync      " :
-                i== WindowSettings::IATTR_HINT_DRAWABLE ?
+                i == WindowSettings::IATTR_HINT_DRAWABLE ?
                     "hint_drawable      " :
-                i== WindowSettings::IATTR_HINT_STATISTICS ?
+                i == WindowSettings::IATTR_HINT_STATISTICS ?
                     "hint_statistics    " :
-                i== WindowSettings::IATTR_HINT_SCREENSAVER ?
+                i == WindowSettings::IATTR_HINT_SCREENSAVER ?
                     "hint_screensaver   " :
-                i== WindowSettings::IATTR_HINT_GRAB_POINTER ?
+                i == WindowSettings::IATTR_HINT_GRAB_POINTER ?
                     "hint_grab_pointer  " :
-                i== WindowSettings::IATTR_PLANES_COLOR ?
+                i == WindowSettings::IATTR_PLANES_COLOR ?
                     "planes_color       " :
-                i== WindowSettings::IATTR_PLANES_ALPHA ?
+                i == WindowSettings::IATTR_PLANES_ALPHA ?
                     "planes_alpha       " :
-                i== WindowSettings::IATTR_PLANES_DEPTH ?
+                i == WindowSettings::IATTR_PLANES_DEPTH ?
                     "planes_depth       " :
-                i== WindowSettings::IATTR_PLANES_STENCIL ?
+                i == WindowSettings::IATTR_PLANES_STENCIL ?
                     "planes_stencil     " :
-                i== WindowSettings::IATTR_PLANES_ACCUM ?
+                i == WindowSettings::IATTR_PLANES_ACCUM ?
                     "planes_accum       " :
-                i== WindowSettings::IATTR_PLANES_ACCUM_ALPHA ?
+                i == WindowSettings::IATTR_PLANES_ACCUM_ALPHA ?
                     "planes_accum_alpha " :
-                i== WindowSettings::IATTR_PLANES_SAMPLES ?
+                i == WindowSettings::IATTR_PLANES_SAMPLES ?
                     "planes_samples     " : "ERROR" )
            << static_cast< fabric::IAttribute >( value ) << std::endl;
     }

--- a/eq/util/accumBufferObject.cpp
+++ b/eq/util/accumBufferObject.cpp
@@ -96,13 +96,13 @@ void AccumBufferObject::accum( const GLfloat value )
 
     const PixelViewport pvp( 0, 0, getWidth(), getHeight( ));
     _setup( pvp );
-    glEnable( GL_BLEND );
-    glBlendFunc( GL_ONE, GL_ONE );
+    EQ_GL_CALL( glEnable( GL_BLEND ));
+    EQ_GL_CALL( glBlendFunc( GL_ONE, GL_ONE ));
 
     _drawQuadWithTexture( _texture, pvp, value );
 
-    glBlendFunc( GL_ONE, GL_ZERO );
-    glDisable( GL_BLEND );
+    EQ_GL_CALL( glBlendFunc( GL_ONE, GL_ZERO ));
+    EQ_GL_CALL( glDisable( GL_BLEND ));
     _reset();
 }
 
@@ -148,14 +148,14 @@ void AccumBufferObject::_drawQuadWithTexture( Texture* texture,
 {
     texture->bind();
 
-    glDepthMask( false );
-    glDisable( GL_LIGHTING );
-    glEnable( GL_TEXTURE_RECTANGLE_ARB );
-    glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
+    EQ_GL_CALL( glDepthMask( false ));
+    EQ_GL_CALL( glDisable( GL_LIGHTING ));
+    EQ_GL_CALL( glEnable( GL_TEXTURE_RECTANGLE_ARB ));
+    EQ_GL_CALL( glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE ));
     texture->applyWrap();
     texture->applyZoomFilter( FILTER_NEAREST );
 
-    glColor4f( value, value, value, value );
+    EQ_GL_CALL( glColor4f( value, value, value, value ));
 
     const float startX = static_cast< float >( pvp.x );
     const float endX   = static_cast< float >( pvp.x + pvp.w );
@@ -177,8 +177,8 @@ void AccumBufferObject::_drawQuadWithTexture( Texture* texture,
     glEnd();
 
     // restore state
-    glDisable( GL_TEXTURE_RECTANGLE_ARB );
-    glDepthMask( true );
+    EQ_GL_CALL( glDisable( GL_TEXTURE_RECTANGLE_ARB ));
+    EQ_GL_CALL( glDepthMask( true ));
 }
 
 }

--- a/eq/util/base.h
+++ b/eq/util/base.h
@@ -1,15 +1,15 @@
 
-/* Copyright (c) 2008-2010, Stefan Eilemann <eile@equalizergraphics.com> 
+/* Copyright (c) 2008-2010, Stefan Eilemann <eile@equalizergraphics.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
  * by the Free Software Foundation.
- *  
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -18,7 +18,7 @@
 #ifndef EQUTIL_H
 #define EQUTIL_H
 
-/** 
+/**
  * @namespace eq::util
  * @brief Equalizer utility classes
  *
@@ -32,6 +32,7 @@
 #include <eq/util/bitmapFont.h>
 #include <eq/util/frameBufferObject.h>
 #include <eq/util/objectManager.h>
+#include <eq/util/shader.h>
 
 #endif // EQUTIL_H
 

--- a/eq/util/files.cmake
+++ b/eq/util/files.cmake
@@ -7,6 +7,7 @@ set(UTIL_HEADERS
   ../util/frameBufferObject.h
   ../util/objectManager.h
   ../util/pixelBufferObject.h
+  ../util/shader.h
   ../util/texture.h
   ../util/types.h
   )
@@ -18,5 +19,6 @@ set(UTIL_SOURCES
   ../util/frameBufferObject.cpp
   ../util/objectManager.cpp
   ../util/pixelBufferObject.cpp
+  ../util/shader.cpp
   ../util/texture.cpp
   )

--- a/eq/util/frameBufferObject.cpp
+++ b/eq/util/frameBufferObject.cpp
@@ -73,7 +73,7 @@ Error FrameBufferObject::init( const int32_t width, const int32_t height,
 
     // Check for frame dimensions
     GLint maxViewportDims[2];
-    glGetIntegerv( GL_MAX_VIEWPORT_DIMS, &maxViewportDims[0] );
+    EQ_GL_CALL( glGetIntegerv( GL_MAX_VIEWPORT_DIMS, &maxViewportDims[0] ));
     if( width > maxViewportDims[0] || height > maxViewportDims[1] )
         return Error( ERROR_FRAMEBUFFER_INVALID_SIZE );
 
@@ -81,8 +81,12 @@ Error FrameBufferObject::init( const int32_t width, const int32_t height,
         return Error( ERROR_FRAMEBUFFER_INITIALIZED );
 
     // generate and bind the framebuffer
-    glGenFramebuffersEXT( 1, &_fboID );
-    glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, _fboID );
+    EQ_GL_CALL( glGenFramebuffersEXT( 1, &_fboID ));
+    EQ_GL_CALL( glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, _fboID ));
+
+    GLint mask;
+    EQ_GL_CALL( glGetIntegerv( GL_CONTEXT_PROFILE_MASK, &mask ));
+    const bool coreContext = mask & GL_CONTEXT_CORE_PROFILE_BIT;
 
     // create and bind textures
     for( unsigned i = 0; i < _colors.size(); ++i )
@@ -90,7 +94,7 @@ Error FrameBufferObject::init( const int32_t width, const int32_t height,
         _colors[i]->init( colorFormat, width, height );
         _colors[i]->bindToFBO( GL_COLOR_ATTACHMENT0 + i, width, height );
     }
-    if( stencilSize > 0 && GLEW_EXT_packed_depth_stencil )
+    if( stencilSize > 0 && ( GLEW_EXT_packed_depth_stencil || coreContext ))
     {
         _depth.init( GL_DEPTH24_STENCIL8, width, height );
         _depth.bindToFBO( GL_DEPTH_STENCIL_ATTACHMENT, width, height );

--- a/eq/util/objectManager.h
+++ b/eq/util/objectManager.h
@@ -1,5 +1,6 @@
 
-/* Copyright (c) 2007-2014, Stefan Eilemann <eile@equalizergraphics.com>
+/* Copyright (c) 2007-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -82,30 +83,35 @@ public:
     EQ_API unsigned getList( const void* key ) const;
     EQ_API unsigned newList( const void* key, const int num = 1 );
     EQ_API unsigned obtainList( const void* key, const int num = 1 );
-    EQ_API void   deleteList( const void* key );
+    EQ_API void     deleteList( const void* key );
+
+    EQ_API unsigned getVertexArray( const void* key ) const;
+    EQ_API unsigned newVertexArray( const void* key );
+    EQ_API unsigned obtainVertexArray( const void* key );
+    EQ_API void     deleteVertexArray( const void* key );
 
     EQ_API unsigned getTexture( const void* key ) const;
     EQ_API unsigned newTexture( const void* key );
     EQ_API unsigned obtainTexture( const void* key );
-    EQ_API void   deleteTexture( const void* key );
+    EQ_API void     deleteTexture( const void* key );
 
-    EQ_API bool   supportsBuffers() const;
+    EQ_API bool     supportsBuffers() const;
     EQ_API unsigned getBuffer( const void* key ) const;
     EQ_API unsigned newBuffer( const void* key );
     EQ_API unsigned obtainBuffer( const void* key );
-    EQ_API void   deleteBuffer( const void* key );
+    EQ_API void     deleteBuffer( const void* key );
 
-    EQ_API bool   supportsPrograms() const;
+    EQ_API bool     supportsPrograms() const;
     EQ_API unsigned getProgram( const void* key ) const;
     EQ_API unsigned newProgram( const void* key );
     EQ_API unsigned obtainProgram( const void* key );
-    EQ_API void   deleteProgram( const void* key );
+    EQ_API void     deleteProgram( const void* key );
 
-    EQ_API bool   supportsShaders() const;
+    EQ_API bool     supportsShaders() const;
     EQ_API unsigned getShader( const void* key ) const;
     EQ_API unsigned newShader( const void* key, const unsigned type );
     EQ_API unsigned obtainShader( const void* key, const unsigned type );
-    EQ_API void   deleteShader( const void* key );
+    EQ_API void     deleteShader( const void* key );
 
     EQ_API Accum* getEqAccum( const void* key ) const;
     EQ_API Accum* newEqAccum( const void* key );

--- a/eq/util/shader.cpp
+++ b/eq/util/shader.cpp
@@ -1,0 +1,93 @@
+
+/* Copyright (c) 2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                     Daniel Nachbaur <danielnachbaur@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "shader.h"
+
+#include <eq/client/gl.h>
+#include <lunchbox/log.h>
+
+namespace eq
+{
+namespace util
+{
+namespace shader
+{
+
+bool compile( const unsigned shader, const char* source )
+{
+    EQ_GL_CALL( glShaderSource( shader, 1, &source, 0 ));
+    EQ_GL_CALL( glCompileShader( shader ));
+    GLint status;
+    EQ_GL_CALL( glGetShaderiv( shader, GL_COMPILE_STATUS, &status ));
+    if( !status )
+    {
+        GLchar errorLog[1024] = {0};
+        EQ_GL_CALL( glGetShaderInfoLog( shader, 1024, 0, errorLog ));
+        LBWARN << "Failed to compile shader " << shader << ": " << errorLog
+               << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool linkProgram( const unsigned program, const char* vertexShaderSource,
+                  const char* fragmentShaderSource )
+{
+    if( !program || !vertexShaderSource || !fragmentShaderSource )
+    {
+        LBWARN << "Failed to link shader program " << program << ": No valid "
+                  "shader program, vertex or fragment source." << std::endl;
+        return false;
+    }
+
+    const GLuint vertexShader = glCreateShader( GL_VERTEX_SHADER );
+    if( !compile( vertexShader, vertexShaderSource ))
+    {
+        EQ_GL_CALL( glDeleteShader( vertexShader ));
+        return false;
+    }
+
+    const GLuint fragmentShader = glCreateShader( GL_FRAGMENT_SHADER );
+    if( !compile( fragmentShader, fragmentShaderSource ))
+    {
+        EQ_GL_CALL( glDeleteShader( fragmentShader ));
+        return false;
+    }
+
+    EQ_GL_CALL( glAttachShader( program, vertexShader ));
+    EQ_GL_CALL( glAttachShader( program, fragmentShader ));
+    EQ_GL_CALL( glDeleteShader( vertexShader ));
+    EQ_GL_CALL( glDeleteShader( fragmentShader ));
+
+    EQ_GL_CALL( glLinkProgram( program ));
+    GLint status;
+    EQ_GL_CALL( glGetProgramiv( program, GL_LINK_STATUS, &status ));
+    if( !status )
+    {
+        GLchar errorLog[1024] = {0};
+        EQ_GL_CALL( glGetProgramInfoLog( program, 1024, 0, errorLog ));
+        LBWARN << "Failed to link shader program " << program << ": "
+               << errorLog << std::endl;
+        return false;
+    }
+    return true;
+}
+
+}
+}
+}

--- a/eq/util/shader.h
+++ b/eq/util/shader.h
@@ -1,0 +1,58 @@
+
+/* Copyright (c) 2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                     Daniel Nachbaur <danielnachbaur@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef EQUTIL_SHADER_H
+#define EQUTIL_SHADER_H
+
+#include <eq/client/api.h>
+
+namespace eq
+{
+namespace util
+{
+namespace shader
+{
+
+/**
+ * Compile a shader object from a GLSL source and print errors if any.
+ *
+ * @param shader OpenGL shader object
+ * @param source GLSL formatted shader source
+ * @return true on successful compilation, false otherwise
+ * @version 1.9
+ */
+EQ_API bool compile( const unsigned shader, const char* source );
+
+/**
+ * Link a shader program from a given vertex and fragment GLSL source and print
+ * errors if any.
+ *
+ * @param program OpenGL shader program
+ * @param vertexShaderSource GLSL formatted vertex shader source
+ * @param fragmentShaderSource GLSL formatted vertex shader source
+ * @return true on successful linking, false otherwise
+ * @version 1.9
+ */
+EQ_API bool linkProgram( const unsigned program, const char* vertexShaderSource,
+                         const char* fragmentShaderSource );
+
+}
+}
+}
+
+#endif // EQUTIL_SHADER_H

--- a/eq/util/texture.cpp
+++ b/eq/util/texture.cpp
@@ -85,7 +85,7 @@ void Texture::flush()
         return;
 
     LB_TS_THREAD( _thread );
-    glDeleteTextures( 1, &_impl->name );
+    EQ_GL_CALL( glDeleteTextures( 1, &_impl->name ));
     _impl->name = 0;
     _impl->defined = false;
 }
@@ -231,14 +231,18 @@ void Texture::_grow( const int32_t width, const int32_t height )
 
 void Texture::applyZoomFilter( const ZoomFilter zoomFilter ) const
 {
-    glTexParameteri( _impl->target, GL_TEXTURE_MAG_FILTER, zoomFilter );
-    glTexParameteri( _impl->target, GL_TEXTURE_MIN_FILTER, zoomFilter );
+    EQ_GL_CALL( glTexParameteri( _impl->target, GL_TEXTURE_MAG_FILTER,
+                                 zoomFilter ));
+    EQ_GL_CALL( glTexParameteri( _impl->target, GL_TEXTURE_MIN_FILTER,
+                                 zoomFilter ));
 }
 
 void Texture::applyWrap() const
 {
-    glTexParameteri( _impl->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-    glTexParameteri( _impl->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+    EQ_GL_CALL( glTexParameteri( _impl->target, GL_TEXTURE_WRAP_S,
+                                 GL_CLAMP_TO_EDGE ));
+    EQ_GL_CALL( glTexParameteri( _impl->target, GL_TEXTURE_WRAP_T,
+                                 GL_CLAMP_TO_EDGE ));
 }
 
 void Texture::copyFromFrameBuffer( const GLuint internalFormat,
@@ -256,7 +260,8 @@ void Texture::copyFromFrameBuffer( const GLuint internalFormat,
     else
         resize( _impl->width, _impl->height );
 
-    glCopyTexSubImage2D( _impl->target, 0, 0, 0, pvp.x, pvp.y, pvp.w, pvp.h );
+    EQ_GL_CALL(  glCopyTexSubImage2D( _impl->target, 0, 0, 0, pvp.x, pvp.y,
+                                      pvp.w, pvp.h ));
     EQ_GL_ERROR( "after Texture::copyFromFrameBuffer" );
 }
 
@@ -271,21 +276,22 @@ void Texture::upload( const int32_t width, const int32_t height,
     else
         resize( _impl->width, _impl->height );
 
-    glTexSubImage2D( _impl->target, 0, 0, 0, width, height,
-                     _impl->format, _impl->type, ptr );
+    EQ_GL_CALL( glTexSubImage2D( _impl->target, 0, 0, 0, width, height,
+                                 _impl->format, _impl->type, ptr ));
 }
 
 void Texture::download( void* buffer ) const
 {
     LBASSERT( isValid( ));
-    glBindTexture( _impl->target, _impl->name );
-    glGetTexImage( _impl->target, 0, _impl->format, _impl->type, buffer );
+    EQ_GL_CALL( glBindTexture( _impl->target, _impl->name ));
+    EQ_GL_CALL( glGetTexImage( _impl->target, 0, _impl->format, _impl->type,
+                               buffer ));
 }
 
 void Texture::bind() const
 {
     LBASSERT( _impl->name );
-    glBindTexture( _impl->target, _impl->name );
+    EQ_GL_CALL( glBindTexture( _impl->target, _impl->name ));
 }
 
 void Texture::bindToFBO( const GLenum target, const int32_t width,
@@ -297,11 +303,11 @@ void Texture::bindToFBO( const GLenum target, const int32_t width,
 
     _generate();
 
-    glBindTexture( _impl->target, _impl->name );
-    glTexImage2D( _impl->target, 0, _impl->internalFormat, width, height, 0,
-                  _impl->format, _impl->type, 0 );
-    glFramebufferTexture2DEXT( GL_FRAMEBUFFER, target, _impl->target,
-                               _impl->name, 0 );
+    EQ_GL_CALL( glBindTexture( _impl->target, _impl->name ));
+    EQ_GL_CALL( glTexImage2D( _impl->target, 0, _impl->internalFormat, width, height, 0,
+                              _impl->format, _impl->type, 0 ));
+    EQ_GL_CALL( glFramebufferTexture2DEXT( GL_FRAMEBUFFER, target,
+                                           _impl->target, _impl->name, 0 ));
 
     _impl->width = width;
     _impl->height = height;

--- a/eq/util/types.h
+++ b/eq/util/types.h
@@ -35,6 +35,8 @@ class Texture;
 class BitmapFont;
 class ObjectManager;
 
+namespace shader {}
+
 /** A vector of pointers to eq::util::Texture */
 typedef std::vector< Texture* >  Textures;
 

--- a/examples/eqHello/CMakeLists.txt
+++ b/examples/eqHello/CMakeLists.txt
@@ -1,7 +1,13 @@
-# Copyright (c) 2010 Daniel Pfeifer <daniel@pfeifer-mail.de>
-#               2011 Stefan Eilemann <eile@eyescale.ch>
+# Copyright (c) 2010-2015 Daniel Pfeifer <daniel@pfeifer-mail.de>
+#                         Stefan Eilemann <eile@eyescale.ch>
+#                         Daniel Nachbaur <danielnachbaur@gmail.com>
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 eq_add_example(eqHello
   SOURCES hello.cpp
+  SHADERS
+    vertexShader.glsl
+    fragmentShader.glsl
   LINK_LIBRARIES ${EQUALIZER_SEQUEL_LIBRARY}
   )

--- a/examples/eqHello/fragmentShader.glsl
+++ b/examples/eqHello/fragmentShader.glsl
@@ -1,0 +1,10 @@
+#version 330 core
+
+in vec3 fragmentColor;
+
+out vec3 color;
+
+void main()
+{
+    color = vec3(0.7,0.7,0.7) * fragmentColor;
+}

--- a/examples/eqHello/hello.cpp
+++ b/examples/eqHello/hello.cpp
@@ -1,5 +1,6 @@
 
-/* Copyright (c) 2007-2014, Stefan Eilemann <eile@equalizergraphics.com>
+/* Copyright (c) 2007-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,16 +33,46 @@
 #include <seq/sequel.h>
 #include <stdlib.h>
 
+#include <fragmentShader.glsl.h>
+#include <vertexShader.glsl.h>
+
 namespace eqHello
 {
 class Renderer : public seq::Renderer
 {
 public:
-    Renderer( seq::Application& application ) : seq::Renderer( application ) {}
+    Renderer( seq::Application& application )
+        : seq::Renderer( application )
+        , _vertexArray( 0 )
+        , _vertexBuffer( 0 )
+        , _indexBuffer( 0 )
+        , _colorBuffer( 0 )
+        , _program( 0 )
+        , _matrixUniform( 0 )
+    {}
     virtual ~Renderer() {}
 
 protected:
-    virtual void draw( co::Object* frameData );
+    void draw( co::Object* frameData ) final;
+    bool initContext( co::Object* initData ) final;
+    bool exitContext() final;
+
+private:
+    bool _loadShaders();
+    void _setupCube();
+
+    typedef vmml::vector< 3, GLushort > Vector3s;
+
+    std::vector< seq::Vector3f > _vertices;
+    std::vector< Vector3s > _triangles;
+    std::vector< seq::Vector3f > _colors;
+
+    GLuint _vertexArray;
+    GLuint _vertexBuffer;
+    GLuint _indexBuffer;
+    GLuint _colorBuffer;
+    GLuint _program;
+    GLuint _matrixUniform;
 };
 
 class Application : public seq::Application
@@ -63,37 +94,148 @@ int main( const int argc, char** argv )
     return EXIT_FAILURE;
 }
 
+void eqHello::Renderer::_setupCube()
+{
+    if( _vertexArray )
+        return;
+
+    _vertices = {
+        // front
+        seq::Vector3f(-0.5, -0.5,  0.5),
+        seq::Vector3f( 0.5, -0.5,  0.5),
+        seq::Vector3f( 0.5,  0.5,  0.5),
+        seq::Vector3f(-0.5,  0.5,  0.5),
+        // back
+        seq::Vector3f(-0.5, -0.5, -0.5),
+        seq::Vector3f( 0.5, -0.5, -0.5),
+        seq::Vector3f( 0.5,  0.5, -0.5),
+        seq::Vector3f(-0.5,  0.5, -0.5)
+    };
+
+    _triangles = {
+        // front
+        Vector3s(0, 1, 2),
+        Vector3s(2, 3, 0),
+        // top
+        Vector3s(3, 2, 6),
+        Vector3s(6, 7, 3),
+        // back
+        Vector3s(7, 6, 5),
+        Vector3s(5, 4, 7),
+        // bottom
+        Vector3s(4, 5, 1),
+        Vector3s(1, 0, 4),
+        // left
+        Vector3s(4, 0, 3),
+        Vector3s(3, 7, 4),
+        // right
+        Vector3s(1, 5, 6),
+        Vector3s(6, 2, 1)
+    };
+
+    _colors = {
+        seq::Vector3f(0.5, 0.5, 0.5),
+        seq::Vector3f(0.5, 0.5, 1.0),
+        seq::Vector3f(0.5, 1.0, 0.5),
+        seq::Vector3f(0.5, 1.0, 1.0),
+        seq::Vector3f(1.0, 0.5, 0.5),
+        seq::Vector3f(1.0, 0.5, 1.0),
+        seq::Vector3f(1.0, 1.0, 0.5),
+        seq::Vector3f(1.0, 1.0, 1.0)
+    };
+
+    seq::ObjectManager& om = getObjectManager();
+
+    _vertexArray = om.newVertexArray( &_vertexArray );
+    EQ_GL_CALL( glBindVertexArray( _vertexArray ));
+
+    _vertexBuffer = om.newBuffer( &_vertexBuffer );
+    EQ_GL_CALL( glBindBuffer( GL_ARRAY_BUFFER, _vertexBuffer ));
+    EQ_GL_CALL( glBufferData( GL_ARRAY_BUFFER,
+                              _vertices.size() * sizeof(seq::Vector3f),
+                              _vertices.data(), GL_STATIC_DRAW ));
+    EQ_GL_CALL( glVertexAttribPointer( 0, 3, GL_FLOAT, GL_FALSE, 0, 0 ));
+
+    _colorBuffer = om.newBuffer( &_colorBuffer );
+    EQ_GL_CALL( glBindBuffer( GL_ARRAY_BUFFER, _colorBuffer ));
+    EQ_GL_CALL( glBufferData( GL_ARRAY_BUFFER,
+                              _colors.size() * sizeof(seq::Vector3f),
+                              _colors.data(), GL_STATIC_DRAW ));
+    EQ_GL_CALL( glVertexAttribPointer( 1, 3, GL_FLOAT, GL_FALSE, 0, 0 ));
+
+    _indexBuffer = om.newBuffer( &_indexBuffer );
+    EQ_GL_CALL( glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, _indexBuffer ));
+    EQ_GL_CALL( glBufferData( GL_ELEMENT_ARRAY_BUFFER,
+                              _triangles.size() * sizeof(Vector3s),
+                              _triangles.data(), GL_STATIC_DRAW ));
+
+    EQ_GL_CALL( glBindBuffer( GL_ARRAY_BUFFER, 0 ));
+    EQ_GL_CALL( glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 ));
+    EQ_GL_CALL( glBindVertexArray( 0 ));
+}
+
+bool eqHello::Renderer::_loadShaders()
+{
+    seq::ObjectManager& om = getObjectManager();
+
+    if( _program )
+        return true;
+
+    _program = om.newProgram( &_program );
+    if( !seq::linkProgram( _program, vertexShader_glsl, fragmentShader_glsl ))
+        return false;
+
+    EQ_GL_CALL( glUseProgram( _program ));
+    _matrixUniform = glGetUniformLocation( _program, "MVP" );
+    EQ_GL_CALL( glUseProgram( 0));
+    return true;
+}
+
+bool eqHello::Renderer::initContext( co::Object* initData )
+{
+    if( !seq::Renderer::initContext( initData ))
+        return false;
+
+    if( !_loadShaders( ))
+        return false;
+
+    _setupCube();
+    return true;
+}
+
+bool eqHello::Renderer::exitContext()
+{
+    seq::ObjectManager& om = getObjectManager();
+    om.deleteProgram( &_program );
+    om.deleteBuffer( &_vertexBuffer );
+    om.deleteBuffer( &_colorBuffer );
+    om.deleteBuffer( &_indexBuffer );
+    om.deleteVertexArray( &_vertexArray );
+
+    return seq::Renderer::exitContext();
+}
+
 /** The rendering routine, a.k.a., glutDisplayFunc() */
 void eqHello::Renderer::draw( co::Object* /*frameData*/ )
 {
     applyRenderContext(); // set up OpenGL State
 
-    const float lightPos[] = { 0.0f, 0.0f, 1.0f, 0.0f };
-    glLightfv( GL_LIGHT0, GL_POSITION, lightPos );
+    const seq::Matrix4f mvp = getFrustum().compute_matrix() * getViewMatrix() *
+                              getModelMatrix();
 
-    const float lightAmbient[] = { 0.2f, 0.2f, 0.2f, 1.0f };
-    glLightfv( GL_LIGHT0, GL_AMBIENT, lightAmbient );
+    EQ_GL_CALL( glUseProgram( _program ));
+    EQ_GL_CALL( glUniformMatrix4fv( _matrixUniform, 1, GL_FALSE, &mvp[0] ));
+    EQ_GL_CALL( glBindVertexArray( _vertexArray ));
+    EQ_GL_CALL( glEnableVertexAttribArray( 0 ));
+    EQ_GL_CALL( glEnableVertexAttribArray( 1 ));
+    EQ_GL_CALL( glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, _indexBuffer ));
 
-    applyModelMatrix(); // global camera
+    EQ_GL_CALL( glDrawElements( GL_TRIANGLES, GLsizei(_triangles.size() * 3),
+                                GL_UNSIGNED_SHORT, 0 ));
 
-    // render six axis-aligned colored quads around the origin
-    for( int i = 0; i < 6; i++ )
-    {
-        glColor3f( (i&1) ? 0.5f:1.0f, (i&2) ? 1.0f:0.5f, (i&4) ? 1.0f:0.5f );
-
-        glNormal3f( 0.0f, 0.0f, 1.0f );
-        glBegin( GL_TRIANGLE_STRIP );
-            glVertex3f(  .7f,  .7f, -1.0f );
-            glVertex3f( -.7f,  .7f, -1.0f );
-            glVertex3f(  .7f, -.7f, -1.0f );
-            glVertex3f( -.7f, -.7f, -1.0f );
-        glEnd();
-
-        if( i < 3 )
-            glRotatef(  90.0f, 0.0f, 1.0f, 0.0f );
-        else if( i == 3 )
-            glRotatef(  90.0f, 1.0f, 0.0f, 0.0f );
-        else
-            glRotatef( 180.0f, 1.0f, 0.0f, 0.0f );
-    }
+    EQ_GL_CALL( glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 ));
+    EQ_GL_CALL( glDisableVertexAttribArray( 1 ));
+    EQ_GL_CALL( glDisableVertexAttribArray( 0 ));
+    EQ_GL_CALL( glBindVertexArray( 0 ));
+    EQ_GL_CALL( glUseProgram( 0 ));
 }

--- a/examples/eqHello/vertexShader.glsl
+++ b/examples/eqHello/vertexShader.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+
+layout(location = 0) in vec3 vertexPosition;
+layout(location = 1) in vec3 vertexColor;
+
+out vec3 fragmentColor;
+
+uniform mat4 MVP;
+
+void main()
+{
+    gl_Position = MVP * vec4(vertexPosition, 1);
+    fragmentColor = vertexColor;
+}

--- a/examples/eqPixelBench/channel.cpp
+++ b/examples/eqPixelBench/channel.cpp
@@ -435,7 +435,7 @@ void Channel::_testDepthAssemble()
         _sendEvent( ASSEMBLE, msec, area, formatType.str(), 0, 0 );
 
         // GLSL
-        if( GLEW_VERSION_2_0 )
+        if( GLEW_VERSION_3_3 )
         {
             formatType.str("");
             formatType << "depth, GLSL,  " << i+1 << " images";

--- a/examples/eqPly/vertexBufferState.h
+++ b/examples/eqPly/vertexBufferState.h
@@ -47,39 +47,36 @@ public:
         , _channel( 0 )
     {}
 
-    virtual ~VertexBufferState() {};
+    virtual ~VertexBufferState() {}
 
-    virtual GLuint getDisplayList( const void* key )
+    GLuint getDisplayList( const void* key ) override
         { return _objectManager.getList( key ); }
 
-    virtual GLuint newDisplayList( const void* key )
+    GLuint newDisplayList( const void* key ) override
         { return _objectManager.newList( key ); }
 
-    virtual GLuint getTexture( const void* key )
-        { return _objectManager.getTexture( key ); }
-
-    virtual GLuint newTexture( const void* key )
-        { return _objectManager.newTexture( key ); }
-
-    virtual GLuint getBufferObject( const void* key )
+    GLuint getBufferObject( const void* key ) override
         { return _objectManager.getBuffer( key ); }
 
-    virtual GLuint newBufferObject( const void* key )
+    GLuint newBufferObject( const void* key ) override
         { return _objectManager.newBuffer( key ); }
 
-    virtual GLuint getProgram( const void* key )
+    void deleteAll()  override
+        { _objectManager.deleteAll(); }
+
+    GLuint getProgram( const void* key )
         { return _objectManager.getProgram( key ); }
 
-    virtual GLuint newProgram( const void* key )
+    GLuint newProgram( const void* key )
         { return _objectManager.newProgram( key ); }
 
-    virtual GLuint getShader( const void* key )
-        { return _objectManager.getShader( key ); }
+    bool linkProgram( const unsigned program, const char* vertexShaderSource,
+                      const char* fragmentShaderSource )
+    {
+        return eq::util::shader::linkProgram( program, vertexShaderSource,
+                                              fragmentShaderSource );
+    }
 
-    virtual GLuint newShader( const void* key, GLenum type )
-        { return _objectManager.newShader( key, type ); }
-
-    virtual void deleteAll() { _objectManager.deleteAll(); }
     bool isShared() const { return _objectManager.isShared(); }
 
     void setChannel( Channel* channel ) { _channel = channel; }

--- a/examples/eqPly/window.cpp
+++ b/examples/eqPly/window.cpp
@@ -147,7 +147,7 @@ void Window::_loadLogo()
 
 void Window::_loadShaders()
 {
-    if( _state->getShader( vertexShader_glsl ) != VertexBufferState::INVALID )
+    if( _state->getProgram( getPipe( )) != VertexBufferState::INVALID )
         // already loaded
         return;
 
@@ -159,45 +159,9 @@ void Window::_loadShaders()
         return;
     }
 
-    const GLuint vShader = _state->newShader( vertexShader_glsl,
-                                              GL_VERTEX_SHADER );
-    LBASSERT( vShader != VertexBufferState::INVALID );
-    const GLchar* vShaderPtr = vertexShader_glsl;
-    glShaderSource( vShader, 1, &vShaderPtr, 0 );
-    glCompileShader( vShader );
-
-    GLint status;
-    glGetShaderiv( vShader, GL_COMPILE_STATUS, &status );
-    if( !status )
-    {
-        LBWARN << "Failed to compile vertex shader" << std::endl;
+    const GLuint program = _state->newProgram( getPipe( ));
+    if( !_state->linkProgram( program, vertexShader_glsl, fragmentShader_glsl ))
         return;
-    }
-
-    const GLuint fShader =
-        _state->newShader( fragmentShader_glsl, GL_FRAGMENT_SHADER );
-    LBASSERT( fShader != VertexBufferState::INVALID );
-    const GLchar* fShaderPtr = fragmentShader_glsl;
-    glShaderSource( fShader, 1, &fShaderPtr, 0 );
-    glCompileShader( fShader );
-    glGetShaderiv( fShader, GL_COMPILE_STATUS, &status );
-    if( !status )
-    {
-        LBWARN << "Failed to compile fragment shader" << std::endl;
-        return;
-    }
-
-    const GLuint program = _state->newProgram( getPipe() );
-    LBASSERT( program != VertexBufferState::INVALID );
-    glAttachShader( program, vShader );
-    glAttachShader( program, fShader );
-    glLinkProgram( program );
-    glGetProgramiv( program, GL_LINK_STATUS, &status );
-    if( !status )
-    {
-        LBWARN << "Failed to link shader program" << std::endl;
-        return;
-    }
 
     // turn off OpenGL lighting if we are using our own shaders
     glDisable( GL_LIGHTING );

--- a/seq/detail/channel.cpp
+++ b/seq/detail/channel.cpp
@@ -112,7 +112,7 @@ void Channel::frameDraw( const uint128_t& )
 
 void Channel::applyModelMatrix()
 {
-    glMultMatrixf( getModelMatrix().array );
+    EQ_GL_CALL( glMultMatrixf( getModelMatrix().array ));
 }
 
 void Channel::frameViewFinish( const uint128_t& frameID )

--- a/seq/detail/renderer.cpp
+++ b/seq/detail/renderer.cpp
@@ -1,5 +1,6 @@
 
-/* Copyright (c) 2011-2013, Stefan Eilemann <eile@eyescale.ch>
+/* Copyright (c) 2011-2015, Stefan Eilemann <eile@eyescale.ch>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -45,6 +46,16 @@ Renderer::~Renderer()
 co::Object* Renderer::getFrameData()
 {
     return _pipe->getFrameData();
+}
+
+const ObjectManager& Renderer::getObjectManager() const
+{
+    return _window->getObjectManager();
+}
+
+ObjectManager& Renderer::getObjectManager()
+{
+    return _window->getObjectManager();
 }
 
 const Frustumf& Renderer::getFrustum() const

--- a/seq/detail/renderer.h
+++ b/seq/detail/renderer.h
@@ -1,5 +1,6 @@
 
 /* Copyright (c) 2011-2013, Stefan Eilemann <eile@eyescale.ch>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -35,6 +36,9 @@ namespace detail
         //@{
         co::Object* getFrameData();
         const GLEWContext* glewGetContext() const { return _glewContext; }
+
+        const ObjectManager& getObjectManager() const;
+        ObjectManager& getObjectManager();
 
         const Frustumf& getFrustum() const;
         const Matrix4f& getViewMatrix() const;

--- a/seq/renderer.cpp
+++ b/seq/renderer.cpp
@@ -1,5 +1,6 @@
 
-/* Copyright (c) 2011-2013, Stefan Eilemann <eile@eyescale.ch>
+/* Copyright (c) 2011-2015, Stefan Eilemann <eile@eyescale.ch>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -37,6 +38,16 @@ Renderer::~Renderer()
 co::Object* Renderer::getFrameData()
 {
     return _impl->getFrameData();
+}
+
+const ObjectManager& Renderer::getObjectManager() const
+{
+    return _impl->getObjectManager();
+}
+
+ObjectManager& Renderer::getObjectManager()
+{
+    return _impl->getObjectManager();
 }
 
 const GLEWContext* Renderer::glewGetContext() const

--- a/seq/renderer.h
+++ b/seq/renderer.h
@@ -1,5 +1,6 @@
 
-/* Copyright (c) 2011-2013, Stefan Eilemann <eile@eyescale.ch>
+/* Copyright (c) 2011-2015, Stefan Eilemann <eile@eyescale.ch>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -162,6 +163,12 @@ public:
 
     /** @return the application instance for this renderer. @version 1.0 */
     const Application& getApplication() const { return app_; }
+
+    /** @return the object manager of this renderer. @version 1.0 */
+    SEQ_API const ObjectManager& getObjectManager() const;
+
+    /** @return the object manager of this renderer. @version 1.0 */
+    SEQ_API ObjectManager& getObjectManager();
 
     /**
      * Create a new per-view data instance.

--- a/seq/types.h
+++ b/seq/types.h
@@ -29,6 +29,8 @@ using eq::Vector3f;
 using eq::Vector4f;
 using eq::uint128_t;
 using eq::fabric::RenderContext;
+using eq::util::ObjectManager;
+using namespace eq::util::shader;
 
 class Application;
 class ObjectFactory;


### PR DESCRIPTION
The support entitles GLX, WGL and Qt. The configuration file learned the new 
hints core_profile, opengl_major and opengl_minor. The eqHello example was
modified accordingly to work with OpenGL 3.3+ core profile contexts. The
different decomposition modes like 2D, DB, subpixel, etc. are working, but
features like viewport outlining, statistics rendering, etc. are not
considered.