### PR TITLE
Fixes for VirtuaGL.

### DIFF
--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -2,7 +2,7 @@
 git_subproject(vmmlib https://github.com/Eyescale/vmmlib.git 2bec113)
 git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git 33546f1)
 git_subproject(Pression https://github.com/Eyescale/Pression.git 93883cf)
-git_subproject(hwsd https://github.com/Eyescale/hwsd.git 0ecf64a)
+git_subproject(hwsd https://github.com/Eyescale/hwsd.git f20749f)
 git_subproject(Collage https://github.com/Eyescale/Collage.git 182698e)
 git_subproject(GLStats https://github.com/Eyescale/GLStats.git 3c76246)
 git_subproject(Deflect https://github.com/BlueBrain/Deflect.git 8556bc3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(GitExternal)
 
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "10")
-set(VERSION_PATCH "0")
+set(VERSION_PATCH "1")
 set(VERSION_ABI 191)
 
 set(EQUALIZER_INCLUDE_NAME eq)

--- a/eq/server/config/resources.cpp
+++ b/eq/server/config/resources.cpp
@@ -315,19 +315,23 @@ bool Resources::discover( ServerPtr server, Config* config,
         std::stringstream name;
         if( info.device == LB_UNDEFINED_UINT32 &&
             // VirtualGL display redirects to local GPU (see continue above)
-            !(info.flags & hwsd::GPUInfo::FLAG_VIRTUALGL) )
+            !(info.flags & hwsd::GPUInfo::FLAG_VIRTUALGL ))
         {
             name << "display";
         }
         else
         {
             name << "GPU" << ++gpuCounter;
-            if( info.flags & hwsd::GPUInfo::FLAG_VIRTUALGL &&
+            if( // When running under VirtualGL, GPUs that are not VNC virtual
+                // devices mustn't be interposed.
+                ( info.flags & ( hwsd::GPUInfo::FLAG_VIRTUALGL |
+                                 hwsd::GPUInfo::FLAG_VNC )) ==
+                    hwsd::GPUInfo::FLAG_VIRTUALGL &&
                 info.device != LB_UNDEFINED_UINT32 )
             {
                 std::ostringstream displayString;
                 displayString << ":" << info.port << "." << info.device;
-                excludedDisplays += displayString.str() + ";";
+                excludedDisplays += displayString.str() + ",";
             }
         }
 


### PR DESCRIPTION
Correction of VGL_EXCLUDE variable generation to use , instead of ;. This
is the separator finally adopted by the upstream version 2.4.80.

VNC displays must be interposed when running under vglrun, but hwsd was not
providing enough information to detect a VNC display. This is also fixed
in this commit.