### PR TITLE
Improved support for multi-device configurations using Qt.

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -28,6 +28,10 @@ Changelog {#Changelog}
   Fixed Qt5 support on OS X
 * [463](https://github.com/Eyescale/Equalizer/pull/463):
   Standalone Qt5 support
+* [499](https://github.com/Eyescale/Equalizer/pull/499):
+  Fixes for VirtualGL 2.4.80 with multi-pipe configurations
+* [502](https://github.com/Eyescale/Equalizer/pull/500):
+  Fixed support of multi-pipe configurations in Qt.
 
 # Release 1.9 (07-07-2015) {#Release19}
 

--- a/eq/pipe.h
+++ b/eq/pipe.h
@@ -253,6 +253,16 @@ public:
     EQ_API virtual void setDirty( const uint64_t bits );
 
 protected:
+    /** @name Information queries */
+    //@{
+    /**
+     * @return true if this pipe can use the requested window system given its
+     *         port and device.
+     * @version 1.11
+     */
+    EQ_API bool isWindowSystemAvailable( const std::string& name ) const;
+    //@}
+
     /** @name Operations */
     //@{
     /**

--- a/eq/qt/window.cpp
+++ b/eq/qt/window.cpp
@@ -44,16 +44,17 @@ QOpenGLContext* _getShareContext( const WindowSettings& settings )
 }
 
 detail::Window* Window::createImpl( const WindowSettings& settings,
-                                    QThread* thread )
+                                    QScreen* screen, QThread* thread )
 {
     QOpenGLContext* shareContext = _getShareContext( settings );
 
     const int32_t drawable = getAttribute( IATTR_HINT_DRAWABLE );
     detail::Window* window = 0;
     if( drawable == eq::WINDOW )
-        window = new detail::QWindowWrapper( settings, shareContext );
+        window = new detail::QWindowWrapper( settings, screen, shareContext );
     else
-        window = new detail::QOffscreenSurfaceWrapper( settings, shareContext );
+        window = new detail::QOffscreenSurfaceWrapper( settings, screen,
+                                                       shareContext );
 
     if( thread )
         window->getContext()->moveToThread( thread );

--- a/eq/qt/window.h
+++ b/eq/qt/window.h
@@ -23,6 +23,7 @@
 #include <eq/qt/types.h>
 #include <eq/glWindow.h> // base class
 #include <QObject> // base class
+#include <QScreen>
 
 namespace eq
 {
@@ -141,7 +142,8 @@ signals:
 
 private:
     detail::Window* const _impl;
-    static detail::Window* createImpl( const WindowSettings&, QThread* );
+    static detail::Window* createImpl( const WindowSettings&,
+                                       QScreen*, QThread* );
     friend class WindowFactory;
 };
 }

--- a/eq/qt/windowFactory.cpp
+++ b/eq/qt/windowFactory.cpp
@@ -20,15 +20,46 @@
 #include "window.h"
 #include "windowImpl.h"
 
+#include "eq/pipe.h"
+
+#include <QGuiApplication>
+
 namespace eq
 {
 namespace qt
 {
 
-detail::Window* WindowFactory::onCreateImpl( const WindowSettings& settings,
+detail::Window* WindowFactory::onCreateImpl( const eq::Pipe* pipe,
+                                             const WindowSettings& settings,
                                              QThread* thread_ )
 {
-    return Window::createImpl( settings, thread_ );
+    // Trying to infer the screen to use from the pipe device number.
+    // We will simply assume that each QScreen belongs to a display and that
+    // each GPU drives a different display. This will work for most setups,
+    // but will break at the moment a single GPU is driving more than one
+    // screen. The only solution in those cases is to adjust manually the
+    // configuration to the setup.
+    QGuiApplication* app =
+        dynamic_cast< QGuiApplication* >( QCoreApplication::instance( ));
+    LBASSERT(app);
+
+    QList< QScreen* > screens = app->screens();
+    QScreen* screen;
+    const unsigned int device = pipe->getDevice();
+    if( device == LB_UNDEFINED_UINT32 )
+        screen = app->primaryScreen();
+    else if( int(device) >= screens.size( ))
+    {
+        LBWARN << "Cannot used device number " << device << ", Qt detected "
+                  "only " << screens.size() << " screens. Using the default"
+                  " screen instead" << std::endl;
+        screen = app->primaryScreen();
+    }
+    else
+    {
+        screen = screens[device];
+    }
+    return Window::createImpl( settings, screen, thread_ );
 }
 
 void WindowFactory::onDestroyImpl( detail::Window* window )

--- a/eq/qt/windowFactory.h
+++ b/eq/qt/windowFactory.h
@@ -32,7 +32,8 @@ class WindowFactory : public QObject
     Q_OBJECT
 
 public slots:
-    detail::Window* onCreateImpl( const WindowSettings&, QThread* );
+    detail::Window* onCreateImpl( const eq::Pipe*, const WindowSettings&,
+                                  QThread* );
     void onDestroyImpl( detail::Window* window );
 };
 

--- a/eq/qt/windowImpl.h
+++ b/eq/qt/windowImpl.h
@@ -143,10 +143,11 @@ class QWindowWrapper : public Window, public QWindow
 {
 public:
     QWindowWrapper( const WindowSettings& settings,
-                    QOpenGLContext* shareContext )
+                    QScreen* screen_, QOpenGLContext* shareContext )
         : _context( new QOpenGLContext )
         , _exposed( false )
     {
+        setScreen( screen_ );
         const QSurfaceFormat& format_ = _createFormat( settings );
         setFormat( format_ );
         const PixelViewport& pvp = settings.getPixelViewport();
@@ -285,9 +286,10 @@ class QOffscreenSurfaceWrapper : public Window, public QOffscreenSurface
 {
 public:
     QOffscreenSurfaceWrapper( const WindowSettings& settings,
-                              QOpenGLContext* shareContext )
+                              QScreen* screen_, QOpenGLContext* shareContext )
         : _context( new QOpenGLContext )
     {
+        setScreen( screen_ );
         const QSurfaceFormat& format_ = _createFormat( settings );
         setFormat( format_ );
 

--- a/eq/qt/windowSystem.cpp
+++ b/eq/qt/windowSystem.cpp
@@ -48,8 +48,10 @@ WindowSystem::WindowSystem()
         return;
 
     _factory->moveToThread( app->thread( ));
-    app->connect( this, SIGNAL( createImpl( const WindowSettings&, QThread* )),
-                  _factory, SLOT( onCreateImpl( const WindowSettings&,
+    app->connect( this, SIGNAL( createImpl( const eq::Pipe*,
+                                            const WindowSettings&, QThread* )),
+                  _factory, SLOT( onCreateImpl( const eq::Pipe*,
+                                                const WindowSettings&,
                                                 QThread* )),
                   Qt::BlockingQueuedConnection );
 }
@@ -72,7 +74,8 @@ eq::SystemWindow* WindowSystem::createWindow( eq::Window* window,
     // Note that even a QOffscreenSurface is backed by a QWindow on some
     // platforms.
     window->getClient()->interruptMainThread();
-    qt::detail::Window* impl = createImpl( settings, QThread::currentThread( ));
+    qt::detail::Window* impl = createImpl( window->getPipe(), settings,
+                                           QThread::currentThread( ));
     Window* qtWindow = new Window( *window, settings, impl );
     qtWindow->connect( qtWindow, SIGNAL( destroyImpl( detail::Window* )),
                       _factory, SLOT( onDestroyImpl( detail::Window* )));

--- a/eq/qt/windowSystem.h
+++ b/eq/qt/windowSystem.h
@@ -37,7 +37,8 @@ public:
     EQ_API ~WindowSystem();
 
 signals:
-    eq::qt::detail::Window* createImpl( const WindowSettings&, QThread* );
+    eq::qt::detail::Window* createImpl( const eq::Pipe*, const WindowSettings&,
+                                        QThread* );
 
 private:
     WindowFactory* _factory;

--- a/examples/eqPly/pipe.cpp
+++ b/examples/eqPly/pipe.cpp
@@ -39,7 +39,10 @@ namespace eqPly
 eq::WindowSystem Pipe::selectWindowSystem() const
 {
     const Config* config = static_cast<const Config*>( getConfig( ));
-    return eq::WindowSystem( config->getInitData().getWindowSystem( ));
+    const std::string& ws = config->getInitData().getWindowSystem();
+    if( isWindowSystemAvailable( ws ))
+        return eq::WindowSystem( ws );
+    return eq::Pipe::selectWindowSystem();
 }
 
 bool Pipe::configInit( const eq::uint128_t& initID )


### PR DESCRIPTION
The solution is not bullet-proof, but will work whenever each device
drives a single display . Due to Qt limitations, the platform specific
windowing system still has to be used as a fallback in some cases (e.g.
when multiple display ports are requested under X).