### PR TITLE
Let the OS choose the server port when the config doesn't have one.

### DIFF
--- a/eq/fabric/types.h
+++ b/eq/fabric/types.h
@@ -33,7 +33,7 @@
 #  define EQ_DEFAULT_PORT (4242)
 #else
 // #241: Avoid using privilege ports below 1024
-#  define EQ_DEFAULT_PORT ( (getuid() % 64511) + 1024 )
+#  define EQ_DEFAULT_PORT (( getuid() % 64511 ) + 1024 )
 #endif
 
 namespace eq

--- a/eq/server/convert11Visitor.h
+++ b/eq/server/convert11Visitor.h
@@ -46,7 +46,7 @@ class ConvertTo11Visitor : public ServerVisitor
             LBINFO << "Adding default server connection for multi-node config"
                    << std::endl;
             co::ConnectionDescriptionPtr desc = new co::ConnectionDescription;
-            desc->port = EQ_DEFAULT_PORT;
+            desc->port = 0; // Let the OS choose the port.
             server->addConnectionDescription( desc );
         }
         return TRAVERSE_CONTINUE;

--- a/eq/server/loader.y
+++ b/eq/server/loader.y
@@ -578,7 +578,7 @@ serverConnection: EQTOKEN_CONNECTION
         '{' {
                 connectionDescription = new eq::server::ConnectionDescription;
                 connectionDescription->setHostname( "" );
-                connectionDescription->port = EQ_DEFAULT_PORT;
+                connectionDescription->port = 0; // OS chosen port
             }
             connectionFields '}'
             {

--- a/tools/server/eqServer.cpp
+++ b/tools/server/eqServer.cpp
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
  * by the Free Software Foundation.
- *  
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.


### PR DESCRIPTION
Among other things, this is needed to be able to run tests that use
config files in parallel reliably.