### PR TITLE
Added missing wheel event handler in EventHandler.

### DIFF
--- a/eq/qt/eventHandler.cpp
+++ b/eq/qt/eventHandler.cpp
@@ -220,6 +220,10 @@ WindowEvent* EventHandler::_translateEvent( QEvent* qevent )
         return _mousePressEvent( static_cast< QMouseEvent* >( qevent ));
     case QEvent::MouseButtonRelease:
         return _mouseReleaseEvent( static_cast< QMouseEvent* >( qevent ));
+#ifndef QT_NO_WHEELEVENT
+    case QEvent::Wheel:
+        return _wheelEvent( static_cast< QWheelEvent* >( qevent ));
+#endif
     case QEvent::KeyPress:
         return _keyEvent( static_cast< QKeyEvent* >( qevent ),
                           Event::KEY_PRESS);


### PR DESCRIPTION
This is needed to get wheel events sent to the config when the
Qt window is offscreen (but is being forwarded the events).