### PR TITLE
Move two hidden common_find_package to top-level CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,10 @@ endif()
 
 common_find_package(Boost REQUIRED COMPONENTS
   program_options filesystem system thread)
+common_find_package(BISON REQUIRED)
 common_find_package(Collage REQUIRED)
 common_find_package(Deflect)
+common_find_package(FLEX REQUIRED)
 common_find_package(GLStats)
 common_find_package(hwloc)
 common_find_package(hwsd)

--- a/eq/server/CMakeLists.txt
+++ b/eq/server/CMakeLists.txt
@@ -2,9 +2,6 @@
 #                         Stefan Eilemann <eile@eyescale.ch>
 #                         Daniel Nachbaur <danielnachbaur@gmail.com>
 
-common_find_package(BISON REQUIRED)
-common_find_package(FLEX  REQUIRED)
-
 bison_target(PARSER loader.y ${CMAKE_CURRENT_BINARY_DIR}/parser.cpp
   COMPILE_FLAGS "-l -p eqLoader_")
 


### PR DESCRIPTION
Those were causing the configuration of a super-project using Equalizer (e.g. viz/stable) to fail with the error: "missing target EqualizerServer" instead of skipping the subproject when BISON or FLEX are not installed.